### PR TITLE
Use container id for docker commands

### DIFF
--- a/compose/magento-2-windows/bin/copydir.ps1
+++ b/compose/magento-2-windows/bin/copydir.ps1
@@ -3,4 +3,4 @@ Param(
   [Parameter(Mandatory=$True,Position=1)]
   [string]$dir
 )
-docker cp $(docker-compose ps|grep phpfpm|awk '{print $dir}'):/var/www/html/$dir src/
+docker cp $(docker-compose ps -q phpfpm|awk '{print $dir}'):/var/www/html/$dir src/

--- a/compose/magento-2/bin/copyfromcontainer
+++ b/compose/magento-2/bin/copyfromcontainer
@@ -2,9 +2,9 @@
 [ -z "$1" ] && echo "Please specify a directory or file to copy from container (ex. vendor, --all)" && exit
 
 if [ "$1" == "--all" ]; then
-  docker cp $(docker-compose ps|grep phpfpm|awk '{print $1}'):/var/www/html/./ src/
+  docker cp $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/./ src/
   echo "Completed copying all files from container to host"
 else
-  docker cp $(docker-compose ps|grep phpfpm|awk '{print $1}'):/var/www/html/$1 src/
+  docker cp $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$1 src/
   echo "Completed copying $1 from container to host"
 fi

--- a/compose/magento-2/bin/copytocontainer
+++ b/compose/magento-2/bin/copytocontainer
@@ -2,10 +2,10 @@
 [ -z "$1" ] && echo "Please specify a directory or file to copy to container (ex. vendor, --all)" && exit
 
 if [ "$1" == "--all" ]; then
-  docker cp src/./ $(docker-compose ps|grep phpfpm|awk '{print $1}'):/var/www/html/
+  docker cp src/./ $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/
   echo "Completed copying all files from host to container"
 else
-  docker cp src/$1 $(docker-compose ps|grep phpfpm|awk '{print $1}'):/var/www/html/
+  docker cp src/$1 $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/
   echo "Completed copying $1 from host to container"
 fi
 


### PR DESCRIPTION
> FYI, I came across this issue using the [mage2click/docker-magento-mutagen](https://github.com/mage2click/docker-magento-mutagen) project which is based off of this project. I submitted the same PR there: https://github.com/mage2click/docker-magento-mutagen/pull/20

When using the `bin` scripts I noticed that sometimes the commands worked and sometimes they would throw an error like this: 
```
Error: No such container:path: magento-231_phpfpm_1:/var/www/html/auth.json
```

In this situation, my directory name is `docker-magento-231` and the container's name is `docker-magento-231_phpfpm_1`. Weirdly enough anything from the first `-` and before is being omitted from the docker commands. I found that the width of the terminal window was actually affecting this. 

**Example**
If the window was wide enough the docker commands run just fine because the container name is correct

![image](https://user-images.githubusercontent.com/2491416/57812574-0b695280-7733-11e9-9c1d-d106b15e6d63.png)

If the window is too narrow the container name is trimmed because the docker-compose name output is multi-lined

![image](https://user-images.githubusercontent.com/2491416/57812649-4c616700-7733-11e9-9d69-a91fe04b7300.png)

I found that the issue lies when grep is used to retrieve the container name. I tested out `grep` in a different scenario and it doesn't seem to be the cause of the issue. A co-worker actually mentioned that this could have something to do with `docker-compose` and how the data is piped.

I didn't dig too much into the situation because I went the route of using the container id instead for the `docker` commands.

