### PR TITLE
Fix Magento2 setup script with n98-magerun2.phar

### DIFF
--- a/compose/magento-2/bin/setup
+++ b/compose/magento-2/bin/setup
@@ -11,7 +11,7 @@ sleep 1 #Ensure containers are started...
 
 curl -O https://files.magerun.net/n98-magerun2.phar
 chmod +x n98-magerun2.phar
-mv n98-magerun2.phar src/bin/n98-magerun2
+mv n98-magerun2.phar src/bin/n98-magerun2.phar
 
 echo "Copying all files from host to container..."
 rm -rf src/vendor #Clear for step below


### PR DESCRIPTION
I fixed setup script where is used n98-magerun2 without .phar extension.

In bin/n98-magerun2 file is call:
#!/bin/bash
bin/cli bin/n98-magerun2.phar "$@"

and it didn't work when we had saved magerun script: src/bin/n98-magerun