### PR TITLE
Fix dev-urn-catalog-generate

### DIFF
--- a/compose/magento-2/bin/dev-urn-catalog-generate
+++ b/compose/magento-2/bin/dev-urn-catalog-generate
@@ -2,7 +2,12 @@
 bin/magento dev:urn-catalog:generate misc.xml
 bin/copyfromcontainer misc.xml
 
-mkdir -p src/.idea
-mv src/misc.xml src/.idea/misc.xml
+REAL_SRC=$(cd -P "src" && pwd)
+
+sed -i .bak "s?/var/www/html?$REAL_SRC?g" $REAL_SRC/misc.xml
+rm $REAL_SRC/misc.xml.bak
+
+mkdir -p $REAL_SRC/.idea
+mv $REAL_SRC/misc.xml $REAL_SRC/.idea/misc.xml
 
 echo "URN's have been generated, you may now restart PHPStorm"


### PR DESCRIPTION
Fix dev-urn-catalog-generate :
Restore the sed replace and made it globally (some <resource> are multiline)
Works if src is a symlink 

