### PR TITLE
Allow 'src' being a symlink to actual directory of Magento project on disk

### DIFF
--- a/compose/magento-2/bin/copyfromcontainer
+++ b/compose/magento-2/bin/copyfromcontainer
@@ -1,11 +1,11 @@
 #!/bin/bash
 [ -z "$1" ] && echo "Please specify a directory or file to copy from container (ex. vendor, --all)" && exit
 
+REAL_SRC=$(cd -P "src" && pwd)
 if [ "$1" == "--all" ]; then
-  docker cp $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/./ src/
+  docker cp $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/./ $REAL_SRC/
   echo "Completed copying all files from container to host"
 else
-  mkdir -p src/$1
-  docker cp $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$1 src/$1/../
+  docker cp $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$1 $REAL_SRC/
   echo "Completed copying $1 from container to host"
 fi

--- a/compose/magento-2/bin/copytocontainer
+++ b/compose/magento-2/bin/copytocontainer
@@ -1,14 +1,14 @@
 #!/bin/bash
 [ -z "$1" ] && echo "Please specify a directory or file to copy to container (ex. vendor, --all)" && exit
 
+REAL_SRC=$(cd -P "src" && pwd)
 if [ "$1" == "--all" ]; then
-  docker cp src/./ $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/
+  docker cp $REAL_SRC/./ $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/
   echo "Completed copying all files from host to container"
   bin/fixowns
   bin/fixperms
 else
-  bin/cli mkdir -p $1
-  docker cp src/$1 $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$1/../
+  docker cp $REAL_SRC/$1 $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$1
   echo "Completed copying $1 from host to container"
   bin/fixowns $1
   bin/fixperms $1


### PR DESCRIPTION
The fix concerns both bin/copyfromcontainer and bin/copytocontainer to allow 'src' being a symlink.
Actually, docker cp fails on copying files on symlink.
The fix consists in resolving "real path" to 'src' to make docker cp.
I choose cd + pwd for Mac OSX compliance.