### PR TITLE
PHP 7.2-fpm-7 missing ioncube .so file FIX

### DIFF
--- a/images/php/7.2/Dockerfile
+++ b/images/php/7.2/Dockerfile
@@ -47,7 +47,7 @@ RUN docker-php-ext-install \
 RUN cd /tmp \
   && curl -o ioncube.tar.gz http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz \
   && tar -xvvzf ioncube.tar.gz \
-  && mv ioncube/ioncube_loader_lin_7.2.so /usr/local/lib/php/extensions/* \
+  && mv ioncube/ioncube_loader_lin_7.2.so /usr/local/lib/php/extensions/ioncube_loader_lin_7.2.so \
   && rm -Rf ioncube.tar.gz ioncube \
   && echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/ioncube_loader_lin_7.2.so" > /usr/local/etc/php/conf.d/00_docker-php-ext-ioncube_loader_lin_7.2.ini 
 


### PR DESCRIPTION
For some reason, the image `7.2-fpm-7` is missing ioncube loader, because it fails to move the file (directory not empty when using the wildcard * character).

```
[razvan@avramescu-net new]$ docker run -ti markoshust/magento-php:7.2-fpm-7 bash
app@49915c118de1:~/html$ ls -alh /usr/local/lib/php/extensions 
total 12K
drwxr-xr-x. 1 root root 4.0K Jan 24 09:28 .
drwxr-xr-x. 1 root root 4.0K Jan 24 09:28 ..
drwxr-xr-x. 1 root root 4.0K Feb  1 01:37 no-debug-non-zts-20170718
```

The change should do the trick. It could also be fixed by just removing the wildcard character.