### PR TITLE
Make sure directory name is converted to lowercase

### DIFF
--- a/compose/bin/removevolumes
+++ b/compose/bin/removevolumes
@@ -1,4 +1,5 @@
 #!/bin/bash
+declare -l current_folder
 current_folder=${PWD##*/}
 docker volume rm ${current_folder}_appdata
 docker volume rm ${current_folder}_dbdata


### PR DESCRIPTION
Since docker uses lower case volume names, make sure to convert the current directory to lowercase before passing it to the docker command.