### PR TITLE
Add ioncube for php 7.2 and 7.3 Dockerfile

### DIFF
--- a/images/php/7.2/Dockerfile
+++ b/images/php/7.2/Dockerfile
@@ -44,12 +44,12 @@ RUN docker-php-ext-install \
   xsl \
   zip
 
-RUN cd /tmp \
-  && curl -o ioncube.tar.gz http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz \
-  && tar -xvvzf ioncube.tar.gz \
-  && mv ioncube/ioncube_loader_lin_7.2.so /usr/local/lib/php/extensions/ioncube_loader_lin_7.2.so \
-  && rm -Rf ioncube.tar.gz ioncube \
-  && echo "zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20151012/ioncube_loader_lin_7.2.so" > /usr/local/etc/php/conf.d/00_docker-php-ext-ioncube_loader_lin_7.2.ini 
+ENV ION_CUBE_PHP_VERSION "7.2"
+RUN PHP_EXTENSION_DIR="$(php-config --extension-dir)" bash -c 'curl http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz -o /ioncube_loaders_lin_x86-64.tar.gz && \
+  tar -xzvf /ioncube_loaders_lin_x86-64.tar.gz -C / && \
+  cp "/ioncube/ioncube_loader_lin_${ION_CUBE_PHP_VERSION}.so" $PHP_EXTENSION_DIR && \
+  echo "zend_extension=${PHP_EXTENSION_DIR}/ioncube_loader_lin_${ION_CUBE_PHP_VERSION}.so" > /usr/local/etc/php/conf.d/00-ioncube.ini && \
+  rm -rf /ioncube /ioncube_loaders_lin_x86-64.tar.gz'
 
 RUN pecl channel-update pecl.php.net \
   && pecl install ssh2-1.1.2 \

--- a/images/php/7.3/Dockerfile
+++ b/images/php/7.3/Dockerfile
@@ -45,6 +45,13 @@ RUN docker-php-ext-install \
   xsl \
   zip
 
+ENV ION_CUBE_PHP_VERSION "7.3"
+RUN PHP_EXTENSION_DIR="$(php-config --extension-dir)" bash -c 'curl http://downloads3.ioncube.com/loader_downloads/ioncube_loaders_lin_x86-64.tar.gz -o /ioncube_loaders_lin_x86-64.tar.gz && \
+  tar -xzvf /ioncube_loaders_lin_x86-64.tar.gz -C / && \
+  cp "/ioncube/ioncube_loader_lin_${ION_CUBE_PHP_VERSION}.so" $PHP_EXTENSION_DIR && \
+  echo "zend_extension=${PHP_EXTENSION_DIR}/ioncube_loader_lin_${ION_CUBE_PHP_VERSION}.so" > /usr/local/etc/php/conf.d/00-ioncube.ini && \
+  rm -rf /ioncube /ioncube_loaders_lin_x86-64.tar.gz'
+
 RUN pecl channel-update pecl.php.net \
   && pecl install xdebug
 


### PR DESCRIPTION
For php7.2 this path of php-ext is changed: 
/usr/local/lib/php/extensions/no-debug-non-zts-20151012/ioncube_loader_lin_7.2.so
/usr/local/lib/php/extensions/no-debug-non-zts-2017XXXX/ioncube_loader_lin_7.2.so
Also add ioncube for php 7.3

Its commit will work normally when path changes again in the future.