### PR TITLE
Add new new cli to connect to the mysql system

### DIFF
--- a/compose/bin/mysql
+++ b/compose/bin/mysql
@@ -1,0 +1,2 @@
+#!/bin/bash
+bin/cli mysql -hdb -umagento -pmagento magento

--- a/compose/bin/mysql
+++ b/compose/bin/mysql
@@ -1,2 +1,2 @@
 #!/bin/bash
-bin/cli mysql -hdb -umagento -pmagento magento
+bin/cli mysql -hdb -umagento -pmagento magento "$@"


### PR DESCRIPTION
Just a quick bin script I am using locally to connect to mysql via the `bin/cli` command

While using your setup I have found it useful to connect to the DB to check some stuff via the command line. Maybe most people will use another client but for me, I like the CLI.

It would be cool to load in the user/password/host etc but I am not too sure how to do this. If you know and let me know I would be happy to update this for you here.