### PR TITLE
Updated bin/remove and bin/status

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,7 @@ You'll now have an updated `bin/update` helper script, and can run it to update 
 - `bin/npm`: Run the npm binary. Ex. `bin/npm install`
 - `bin/pwa-studio`: (BETA) Start the PWA Studio server. Note that Chrome will throw SSL cert errors and not allow you to view the site, but Firefox will.
 - `bin/redis`: Run a command from the redis container. Ex. `bin/redis redis-cli monitor`
-- `bin/remove`: Remove all containers.
-- `bin/removevolumes`: Remove all volumes.
+- `bin/remove`: Stop containers and remove containers, and add the `--all` flag to remove all containers, networks, volumes, and images. Ex. `bin/remove --all`
 - `bin/restart`: Stop and then start all containers.
 - `bin/root`: Run any CLI command as root without going into the bash prompt. Ex `bin/root apt-get install nano`
 - `bin/rootnotty`: Run any CLI command as root with no TTY. Ex `bin/rootnotty chown -R app:app /var/www/html`

--- a/compose/bin/remove
+++ b/compose/bin/remove
@@ -1,2 +1,8 @@
 #!/bin/bash
-docker-compose rm
+if [ "$1" == "--all" ]; then
+    # Remove containers, networks, volumes, and images.
+    docker-compose -f docker-compose.yml -f docker-compose.dev.yml down --rmi all --volumes
+else
+    # Stop containers, and remove stopped containers
+    docker-compose -f docker-compose.yml -f docker-compose.dev.yml rm --stop
+fi

--- a/compose/bin/removevolumes
+++ b/compose/bin/removevolumes
@@ -1,5 +1,0 @@
-#!/bin/bash
-current_folder=${PWD##*/}
-docker volume rm ${current_folder}_appdata
-docker volume rm ${current_folder}_dbdata
-docker volume rm ${current_folder}_sockdata

--- a/compose/bin/status
+++ b/compose/bin/status
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose ps
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml ps


### PR DESCRIPTION
Updated `bin/remove` to include `bin/removevolumes` function, and with `--all` can remove all images, containers, networks, and volumes
Also update README.md

Fixed issues: 
1. `docker-compose rm` only remove stoped containers. It should add `--stop`, if required, before removing.
2. `bin/removevolumes`, for volume naming rule need to use lowercase and skip dot `.` characters, and volume list should include rabbitmqdata, ssldata, and appvolumes
3. `bin/status` should appear mailhog status (define in `docker-compose.dev.yml`)

Because English is not my native language, please help me update these description if necessary.
Thanks.
