### PR TITLE
Added bin/removeall and fixed few issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ You'll now have an updated `bin/update` helper script, and can run it to update 
 - `bin/pwa-studio`: (BETA) Start the PWA Studio server. Note that Chrome will throw SSL cert errors and not allow you to view the site, but Firefox will.
 - `bin/redis`: Run a command from the redis container. Ex. `bin/redis redis-cli monitor`
 - `bin/remove`: Remove all containers.
+- `bin/removeall`: Remove all containers, networks, volumes, and images.
 - `bin/removevolumes`: Remove all volumes.
 - `bin/restart`: Stop and then start all containers.
 - `bin/root`: Run any CLI command as root without going into the bash prompt. Ex `bin/root apt-get install nano`

--- a/compose/bin/remove
+++ b/compose/bin/remove
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose rm
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml rm --stop

--- a/compose/bin/removeall
+++ b/compose/bin/removeall
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml down --rmi all --volumes

--- a/compose/bin/removevolumes
+++ b/compose/bin/removevolumes
@@ -1,5 +1,8 @@
 #!/bin/bash
 current_folder=${PWD##*/}
-docker volume rm ${current_folder}_appdata
-docker volume rm ${current_folder}_dbdata
-docker volume rm ${current_folder}_sockdata
+volume_prefix=`echo $current_folder | awk '{print tolower($0)}' | sed 's/\.//g'`
+docker volume rm ${volume_prefix}_appdata
+docker volume rm ${volume_prefix}_dbdata
+docker volume rm ${volume_prefix}_rabbitmqdata
+docker volume rm ${volume_prefix}_sockdata
+docker volume rm ${volume_prefix}_ssldata

--- a/compose/bin/status
+++ b/compose/bin/status
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker-compose ps
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml ps


### PR DESCRIPTION
After discussion #236 and modified this pull
1. Added `bin/removeall` for removing all containers, networks, volumes, and images.
2. Fixed docker-compose issue, it should include docker-compose.yml and docker-compose.dev.yml 
3. `bin/remove`: Add `--stop` param that stop containers first and remove stoped containers
4. Keep `bin/removevolumes` and fixed volume naming rule.
5. Updated README.md

PS: 
Because `bin/removevolumes` action is removing volume only, it will need to maintain in the future when volume setting changing in docker-compose.yml.
The `docker-compose down` is inappropriate because it [default action](https://docs.docker.com/compose/reference/down/) is removing containers and networks
