### PR TITLE
Add checker for docker-compose up

### DIFF
--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -7,7 +7,8 @@ bin/stop
 sed -e 's/5f5929ef9f2ec4ca048a2add261d22c92807630f/ce31e720d60451784b9fdb3769e43e149f50d436/' src/composer.lock > composer.lock && mv composer.lock src/composer.lock
 
 docker-compose -f docker-compose.yml up -d
-sleep 1 #Ensure containers are started...
+[ $? != 0 ] && echo "Failed to start Docker services" && exit
+sleep 5 #Ensure containers are started...
 
 echo "Copying all files from host to container..."
 rm -rf src/vendor #Clear for step below

--- a/compose/bin/start
+++ b/compose/bin/start
@@ -30,12 +30,14 @@ function parseYaml {
 VOLUME_LIST=`parseYaml docker-compose.dev.yml services_app_volumes`
 IGNORE_LIST="./src/app/code ./src/m2-hotfixes ./src/patches ./src/var/log ./src/var/report ./src"
 IS_VALID=true
+# Loop through all files missing from the docker-compose.dev.yml file
 for file in $VOLUME_LIST; do
   if [ ! -e $file ] && [[ ! " $IGNORE_LIST " =~ " $file " ]]; then
     echo "$file: No such file or directory"
     IS_VALID=false
   fi
 done
+# Wait to exit until all missing files have been outputted to the user
 [ $IS_VALID = false ] && echo "Failed to start docker for missing volume files" && exit
 
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d --remove-orphans

--- a/compose/bin/start
+++ b/compose/bin/start
@@ -26,17 +26,17 @@ function parseYaml {
   }'
 }
 
-# Check volume files exsit to avoid creating empty folder
+# Check if volume files exist to avoid creating an empty folder
 VOLUME_LIST=`parseYaml docker-compose.dev.yml services_app_volumes`
 IGNORE_LIST="./src/app/code ./src/m2-hotfixes ./src/patches ./src/var/log ./src/var/report ./src"
-VALID=true
+IS_VALID=true
 for file in $VOLUME_LIST; do
   if [ ! -e $file ] && [[ ! " $IGNORE_LIST " =~ " $file " ]]; then
     echo "$file: No such file or directory"
-    VALID=false
+    IS_VALID=false
   fi
 done
-[ $VALID = false ] && echo "Failed to start docker for missing volume files" && exit
+[ $IS_VALID = false ] && echo "Failed to start docker for missing volume files" && exit
 
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d --remove-orphans
 

--- a/compose/bin/start
+++ b/compose/bin/start
@@ -1,4 +1,43 @@
 #!/bin/bash
+function parseYaml {
+  local s='[[:space:]]*' w='[a-zA-Z0-9_]*' fs=$(echo @|tr @ '\034')
+  sed -ne "s|,$s\]$s\$|]|" \
+      -e ":1;s|^\($s\)\($w\)$s:$s\[$s\(.*\)$s,$s\(.*\)$s\]|\1\2: [\3]\n\1  - \4|;t1" \
+      -e "s|^\($s\)\($w\)$s:$s\[$s\(.*\)$s\]|\1\2:\n\1  - \3|;p" $1 | \
+  sed -ne "s|,$s}$s\$|}|" \
+      -e ":1;s|^\($s\)-$s{$s\(.*\)$s,$s\($w\)$s:$s\(.*\)$s}|\1- {\2}\n\1  \3: \4|;t1" \
+      -e    "s|^\($s\)-$s{$s\(.*\)$s}|\1-\n\1  \2|;p" | \
+  sed -ne "s|^\($s\):|\1|" \
+      -e "s|^\($s\)-$s[\"']\(.*\)[\"']$s\$|\1$fs$fs\2|p" \
+      -e "s|^\($s\)-$s\(.*\)$s\$|\1$fs$fs\2|p" \
+      -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+      -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p" | \
+  awk -F$fs '{
+    indent = length($1)/2;
+    vname[indent] = $2;
+    for (i in vname) {if (i > indent) {delete vname[i]; idx[i]=0}}
+    if (length($2) == 0) {vname[indent] = ++idx[indent] };
+    if (length($3) > 0) {
+      vn=""; for (i=0; i<indent; i++) {vn = (vn)(vname[i])("_")}
+      if ("'$2'_" == vn) {
+         print substr($3 ,0 , match($3,":")-1)
+      }
+    }
+  }'
+}
+
+# Check volume files exsit to avoid creating empty folder
+VOLUME_LIST=`parseYaml docker-compose.dev.yml services_app_volumes`
+IGNORE_LIST="./src/app/code ./src/m2-hotfixes ./src/patches ./src/var/log ./src/var/report ./src"
+VALID=true
+for file in $VOLUME_LIST; do
+  if [ ! -e $file ] && [[ ! " $IGNORE_LIST " =~ " $file " ]]; then
+    echo "$file: No such file or directory"
+    VALID=false
+  fi
+done
+[ $VALID = false ] && echo "Failed to start docker for missing volume files" && exit
+
 docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d --remove-orphans
 
 ## Blackfire support


### PR DESCRIPTION
1. Increase the seconds to ensure containers are started
2. Add volume files validator for `bin/start`. Avoiding to generate useless empty folder when there is a lack of volume files. ex: `./src/composer.json`, `./src/composer.lock`, and `./src/nginx.conf.sample`