### PR TITLE
Add bin/dbdump and improve bin/mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ bin/composer install
 bin/copyfromcontainer vendor
 
 # Import existing database:
-bin/mysql < existing/magento.sql
+bin/mysql < backups/magento.sql
 
 # Update database connection details to use the above Docker MySQL credentials:
 # Also note: creds for the MySQL server are defined at startup from env/db.env
@@ -270,8 +270,8 @@ You'll now have an updated `bin/update` helper script, and can run it to update 
 - `bin/fixperms`: This will fix filesystem permissions within the container.
 - `bin/grunt`: Run the grunt binary. Ex. `bin/grunt exec`
 - `bin/magento`: Run the Magento CLI. Ex: `bin/magento cache:flush`
-- `bin/mysql`: Run the MySQL CLI with database config from `env/db.env`. Ex. `bin/mysql -e "EXPLAIN core_config_data"` or`bin/mysql < backups/mysqldump.sql`
-- `bin/mysqldump`: Backup the Magento database. Ex. `bin/mysqldump > backups/mysqldump.sql`
+- `bin/mysql`: Run the MySQL CLI with database config from `env/db.env`. Ex. `bin/mysql -e "EXPLAIN core_config_data"` or`bin/mysql < backups/magento.sql`
+- `bin/mysqldump`: Backup the Magento database. Ex. `bin/mysqldump > backups/magento.sql`
 - `bin/n98-magerun2`: Access the n98 magerun CLI. Ex: `bin/n98-magerun2 dev:console`
 - `bin/node`: Run the node binary. Ex. `bin/node --version`
 - `bin/npm`: Run the npm binary. Ex. `bin/npm install`
@@ -306,16 +306,16 @@ To connect to the MySQL CLI tool of the Docker instance, run:
 bin/mysql
 ```
 
-You can use the `bin/mysql` script to import a database, for example a file stored in your local host directory at `backups/mysqldump.sql`:
+You can use the `bin/mysql` script to import a database, for example a file stored in your local host directory at `backups/magento.sql`:
 
 ```
-bin/mysql < backups/mysqldump.sql
+bin/mysql < backups/magento.sql
 ```
 
-You also can use `bin/mysqldump` to export the database. The file will appear in your local host directory at `backups/mysqldump.sql`:
+You also can use `bin/mysqldump` to export the database. The file will appear in your local host directory at `backups/magento.sql`:
 
 ```
-bin/mysqldump > backups/mysqldump.sql
+bin/mysqldump > backups/magento.sql
 ```
 
 ### Composer Authentication

--- a/README.md
+++ b/README.md
@@ -263,7 +263,6 @@ You'll now have an updated `bin/update` helper script, and can run it to update 
 - `bin/composer`: Run the composer binary. Ex. `bin/composer install`
 - `bin/copyfromcontainer`: Copy folders or files from container to host. Ex. `bin/copyfromcontainer vendor`
 - `bin/copytocontainer`: Copy folders or files from host to container. Ex. `bin/copytocontainer --all`
-- `bin/dbdump`: Dump configured Magento database with `mysqldump`. Ex. `bin/dbdump > dbdump.sql`
 - `bin/dev-urn-catalog-generate`: Generate URN's for PHPStorm and remap paths to local host. Restart PHPStorm after running this command.
 - `bin/devconsole`: Alias for `bin/n98-magerun2 dev:console`
 - `bin/download`: Download & extract specific Magento version to the `src` directory. Ex. `bin/download 2.3.3`
@@ -271,7 +270,8 @@ You'll now have an updated `bin/update` helper script, and can run it to update 
 - `bin/fixperms`: This will fix filesystem permissions within the container.
 - `bin/grunt`: Run the grunt binary. Ex. `bin/grunt exec`
 - `bin/magento`: Run the Magento CLI. Ex: `bin/magento cache:flush`
-- `bin/mysql`: Run the MySQL CLI with database config from `env/db.env`. Ex. `bin/mysql -e "EXPLAIN core_config_data"` and `bin/mysql < dbdump.sql`
+- `bin/mysql`: Run the MySQL CLI with database config from `env/db.env`. Ex. `bin/mysql -e "EXPLAIN core_config_data"` or`bin/mysql < backups/mysqldump.sql`
+- `bin/mysqldump`: Backup the Magento database. Ex. `bin/mysqldump > backups/mysqldump.sql`
 - `bin/n98-magerun2`: Access the n98 magerun CLI. Ex: `bin/n98-magerun2 dev:console`
 - `bin/node`: Run the node binary. Ex. `bin/node --version`
 - `bin/npm`: Run the npm binary. Ex. `bin/npm install`
@@ -300,22 +300,22 @@ You'll now have an updated `bin/update` helper script, and can run it to update 
 
 The hostname of each service is the name of the service within the `docker-compose.yml` file. So for example, MySQL's hostname is `db` (not `localhost`) when accessing it from within a Docker container. Elasticsearch's hostname is `elasticsearch`.
 
-Here's an example of how to connect to the MySQL CLI tool of the Docker instance:
+To connect to the MySQL CLI tool of the Docker instance, run:
 
 ```
 bin/mysql
 ```
 
-You can use the `bin/mysql` script to import a database. The `dbdump.sql` file is in your local host directory:
+You can use the `bin/mysql` script to import a database, for example a file stored in your local host directory at `backups/mysqldump.sql`:
 
 ```
-bin/mysql < dbdump.sql
+bin/mysql < backups/mysqldump.sql
 ```
 
-You also can use `bin/dbdump` to export a database from magento in Docker container. The `dbdump.sql` file will appear in your local host directory:
+You also can use `bin/mysqldump` to export the database. The file will appear in your local host directory at `backups/mysqldump.sql`:
 
 ```
-bin/dbdump > dbdump.sql
+bin/mysqldump > backups/mysqldump.sql
 ```
 
 ### Composer Authentication

--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ bin/mysql < existing/magento.sql
 bin/magento app:config:import
 
 # Set base URLs to local environment URL (if not defined in env.php file):
-bin/magento setup:store-config:set web/secure/base_url https://yoursite.test/
-bin/magento setup:store-config:set web/unsecure/base_url https://yoursite.test/
+bin/magento config:set web/secure/base_url https://yoursite.test/
+bin/magento config:set web/unsecure/base_url https://yoursite.test/
 
 bin/restart
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ bin/composer install
 bin/copyfromcontainer vendor
 
 # Import existing database:
-bin/clinotty mysql -hdb -umagento -pmagento magento < existing/magento.sql
+bin/mysql < existing/magento.sql
 
 # Update database connection details to use the above Docker MySQL credentials:
 # Also note: creds for the MySQL server are defined at startup from env/db.env
@@ -223,8 +223,8 @@ bin/clinotty mysql -hdb -umagento -pmagento magento < existing/magento.sql
 bin/magento app:config:import
 
 # Set base URLs to local environment URL (if not defined in env.php file):
-bin/magento config:set web/secure/base_url https://yoursite.test/
-bin/magento config:set web/unsecure/base_url https://yoursite.test/
+bin/magento setup:store-config:set web/secure/base_url https://yoursite.test/
+bin/magento setup:store-config:set web/unsecure/base_url https://yoursite.test/
 
 bin/restart
 
@@ -263,6 +263,7 @@ You'll now have an updated `bin/update` helper script, and can run it to update 
 - `bin/composer`: Run the composer binary. Ex. `bin/composer install`
 - `bin/copyfromcontainer`: Copy folders or files from container to host. Ex. `bin/copyfromcontainer vendor`
 - `bin/copytocontainer`: Copy folders or files from host to container. Ex. `bin/copytocontainer --all`
+- `bin/dbdump`: Dump configured Magento database with `mysqldump`. Ex. `bin/dbdump > dbdump.sql`
 - `bin/dev-urn-catalog-generate`: Generate URN's for PHPStorm and remap paths to local host. Restart PHPStorm after running this command.
 - `bin/devconsole`: Alias for `bin/n98-magerun2 dev:console`
 - `bin/download`: Download & extract specific Magento version to the `src` directory. Ex. `bin/download 2.3.3`
@@ -270,7 +271,7 @@ You'll now have an updated `bin/update` helper script, and can run it to update 
 - `bin/fixperms`: This will fix filesystem permissions within the container.
 - `bin/grunt`: Run the grunt binary. Ex. `bin/grunt exec`
 - `bin/magento`: Run the Magento CLI. Ex: `bin/magento cache:flush`
-- `bin/mysql`: Run the MySQL CLI with database config from env/db.env. Ex `bin/mysql -e "EXPLAIN core_config_data"`
+- `bin/mysql`: Run the MySQL CLI with database config from `env/db.env`. Ex. `bin/mysql -e "EXPLAIN core_config_data"` and `bin/mysql < dbdump.sql`
 - `bin/n98-magerun2`: Access the n98 magerun CLI. Ex: `bin/n98-magerun2 dev:console`
 - `bin/node`: Run the node binary. Ex. `bin/node --version`
 - `bin/npm`: Run the npm binary. Ex. `bin/npm install`
@@ -299,16 +300,22 @@ You'll now have an updated `bin/update` helper script, and can run it to update 
 
 The hostname of each service is the name of the service within the `docker-compose.yml` file. So for example, MySQL's hostname is `db` (not `localhost`) when accessing it from within a Docker container. Elasticsearch's hostname is `elasticsearch`.
 
-Here's an example of how to connect to the MySQL cli tool of the Docker instance:
+Here's an example of how to connect to the MySQL CLI tool of the Docker instance:
 
 ```
-bin/cli mysql -h db -umagento -pmagento magento
+bin/mysql
 ```
 
-You can use the `bin/clinotty` helper script to import a database. This example uses the root MySQL user, and looks for the `dbdump.sql` file in your local host directory:
+You can use the `bin/mysql` script to import a database. The `dbdump.sql` file is in your local host directory:
 
 ```
-bin/clinotty mysql -h db -u root -pmagento magento < dbdump.sql
+bin/mysql < dbdump.sql
+```
+
+You also can use `bin/dbdump` to export a database from magento in Docker container. The `dbdump.sql` file will appear in your local host directory:
+
+```
+bin/dbdump > dbdump.sql
 ```
 
 ### Composer Authentication

--- a/compose/bin/dbdump
+++ b/compose/bin/dbdump
@@ -1,0 +1,2 @@
+#!/bin/bash
+bin/n98-magerun2 db:dump --stdout "$@"

--- a/compose/bin/mysql
+++ b/compose/bin/mysql
@@ -1,3 +1,9 @@
 #!/bin/bash
 source env/db.env
-bin/cli mysql -hdb -u${MYSQL_USER} -p${MYSQL_PASSWORD} ${MYSQL_DATABASE} "$@"
+if [ -t 0 ]; then
+  # Need tty to run mysql shell
+  bin/cli mysql -h${MYSQL_HOST} -u${MYSQL_USER} -p${MYSQL_PASSWORD} ${MYSQL_DATABASE} "$@"
+else
+  # Read from stdin, ex: bin/mysql < dbdump.sql
+  bin/clinotty mysql -h${MYSQL_HOST} -u${MYSQL_USER} -p${MYSQL_PASSWORD} ${MYSQL_DATABASE} "$@"
+fi

--- a/compose/bin/n98-magerun2
+++ b/compose/bin/n98-magerun2
@@ -1,8 +1,7 @@
 #!/bin/bash
 if ! bin/clinotty ls bin/n98-magerun2.phar 1> /dev/null 2>&1; then
-    bin/clinotty curl -O https://files.magerun.net/n98-magerun2.phar
-    bin/clinotty chmod +x n98-magerun2.phar
-    bin/clinotty mkdir -p bin
-    bin/clinotty mv n98-magerun2.phar bin/n98-magerun2.phar
+  bin/clinotty mkdir -p bin
+  bin/clinotty curl https://files.magerun.net/n98-magerun2.phar -o bin/n98-magerun2.phar
+  bin/clinotty chmod +x bin/n98-magerun2.phar
 fi
 bin/cli bin/n98-magerun2.phar "$@"

--- a/compose/env/db.env
+++ b/compose/env/db.env
@@ -1,3 +1,4 @@
+MYSQL_HOST=db
 MYSQL_ROOT_PASSWORD=magento
 MYSQL_DATABASE=magento
 MYSQL_USER=magento


### PR DESCRIPTION
1. Update Magento Default version in `lib/onelinesetup`
2. Add `bin/dbdump` to export database.
3. Add `MYSQL_HOST=db` in `env/db.env`. It's only used for this project's bin tools. It's not for environment variables of the percona:5.7 image.
4. Improve `bin/mysql` to detect stdin to use tty or notty
5. Modify `bin/n98-magerun2` for 2 space indent
6. Update `REAME.md`. I have the least confidence for this part ...