### PR TITLE
add ps command to eliminate exception while running integration tests

### DIFF
--- a/images/php/7.3/Dockerfile
+++ b/images/php/7.3/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y \
   lsof \
   default-mysql-client \
   vim \
-  zip
+  zip \
+  procps
 
 RUN docker-php-ext-configure \
   gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/

--- a/images/php/7.4/Dockerfile
+++ b/images/php/7.4/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && apt-get install -y \
   lsof \
   default-mysql-client \
   vim \
-  zip
+  zip \
+  procps
 
 RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 


### PR DESCRIPTION
Install `ps` command on the php container to eliminate while running integration tests:

```
Fatal error: Uncaught Exception: sh: 1: tasklist.exe: not found in /var/www/html/vendor/magento/framework/Shell.php:63
```

It's not a fault of the memory check command in magento core. It's more a workaround for now if you're happy to merge.
Reference in core: https://github.com/magento/magento2/blob/2.4-develop/dev/tests/integration/framework/Magento/TestFramework/Helper/Memory.php#L49-L61

I hope to have some time next week to see if I can fix that in core. Anyway it'll take some time to be released even if fix is merged.

`ps` can also be installed manually using:

```
bin/root apt update
bin/root apt install procps
```