### PR TITLE
Handle nested files in copytocontainer script

### DIFF
--- a/compose/bin/copytocontainer
+++ b/compose/bin/copytocontainer
@@ -8,7 +8,11 @@ if [ "$1" == "--all" ]; then
   bin/fixowns
   bin/fixperms
 else
-  docker cp $REAL_SRC/$1 $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/
+  if [ -f "$REAL_SRC/$1" ]; then
+    docker cp $REAL_SRC/$1 $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$1
+  else
+    docker cp $REAL_SRC/$1 $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$(dirname $1)
+  fi
   echo "Completed copying $1 from host to container"
   bin/fixowns $1
   bin/fixperms $1


### PR DESCRIPTION
Tested with:

For files:
```
touch src/dev/tests/test-file2.txt
bin/copytocontainer dev/tests/test-file2.txt
bin/cli ls dev/tests/test-file2.txt
```

For directories:

```
mkdir -p src/dev/test-dir
touch src/dev/test-dir/test-file1.txt
touch src/dev/test-dir/test-file2.txt
bin/copytocontainer dev/test-dir
bin/cli ls -la dev/test-dir
```

Previous result for above was:
```
bin/copytocontainer dev/test-dir
Completed copying dev/test-dir from host to container
Correcting filesystem ownerships...
chown: cannot access '/var/www/html/dev/test-dir': No such file or directory
Filesystem ownerships corrected.
Correcting filesystem permissions...
find: 'dev/test-dir': No such file or directory
find: 'dev/test-dir': No such file or directory
Filesystem permissions corrected.
```

After the change:
```
bin/copytocontainer dev/test-dir
Completed copying dev/test-dir from host to container
Correcting filesystem ownerships...
Filesystem ownerships corrected.
Correcting filesystem permissions...
Filesystem permissions corrected.
```

Additional note: `docker cp does not create parent directories for DEST_PATH if they do not exist.` so there are still cases in which the above command may fail.