### PR TITLE
improve nested file and directory support for copyfromcontainer

### DIFF
--- a/compose/bin/copyfromcontainer
+++ b/compose/bin/copyfromcontainer
@@ -6,6 +6,10 @@ if [ "$1" == "--all" ]; then
   docker cp $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/./ $REAL_SRC/
   echo "Completed copying all files from container to host"
 else
-  docker cp $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$1 $REAL_SRC/
+  if [ -f "$1" ] ; then
+    docker cp $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$1 $REAL_SRC/$1
+  else
+    docker cp $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$1 $REAL_SRC/$(dirname $1)
+  fi
   echo "Completed copying $1 from container to host"
 fi


### PR DESCRIPTION
Tested with:

For files:
```
bin/cli touch dev/tests/test-file2.txt
bin/copyfromcontainer dev/tests/test-file2.txt
ls -la src/dev/tests/test-file2.txt
```

For directories:
```
bin/cli mkdir -p dev/test-dir
bin/cli touch dev/test-dir/test-file1.txt
bin/cli touch dev/test-dir/test-file2.txt
bin/copyfromcontainer dev/test-dir
ls -la src/dev/test-dir
```

Previous result for above was:
```
bin/copyfromcontainer dev/test-dir
Completed copying dev/test-dir from container to host
ls -la src/dev/test-dir
ls: cannot access 'src/dev/test-dir': No such file or directory
ls -la src/test-dir
total 8
drwxrwxr-x  2 piotr piotr 4096 Aug  8 19:45 .
drwxrwxr-x 17 piotr piotr 4096 Aug  8 22:06 ..
-rw-rw-r--  1 piotr piotr    0 Aug  8 19:45 test-file1.txt
-rw-rw-r--  1 piotr piotr    0 Aug  8 19:45 test-file2.txt
```

After the change:
```
bin/copyfromcontainer dev/test-dir
Completed copying dev/test-dir from container to host
ls -la src/dev/test-dir
total 8
drwxr-xr-x 2 piotr piotr 4096 Aug  8 22:10 .
drwxr-xr-x 6 piotr piotr 4096 Aug  8 22:10 ..
-rw-r--r-- 1 piotr piotr    0 Aug  8 22:09 test-file1.txt
-rw-r--r-- 1 piotr piotr    0 Aug  8 22:10 test-file2.txt
```

