### PR TITLE
Automated tests with bats

### DIFF
--- a/compose/bin/copytocontainer
+++ b/compose/bin/copytocontainer
@@ -1,9 +1,7 @@
 #!/bin/bash
-
 [ -z "$1" ] && echo "Please specify a directory or file to copy to container (ex. vendor, --all)" && exit
 
 REAL_SRC=$(cd -P "src" && pwd)
-echo ${REAL_SRC}
 if [ "$1" == "--all" ]; then
   docker cp $REAL_SRC/./ $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/
   echo "Completed copying all files from host to container"

--- a/compose/bin/copytocontainer
+++ b/compose/bin/copytocontainer
@@ -1,18 +1,22 @@
 #!/bin/bash
+
 [ -z "$1" ] && echo "Please specify a directory or file to copy to container (ex. vendor, --all)" && exit
 
 REAL_SRC=$(cd -P "src" && pwd)
+echo ${REAL_SRC}
 if [ "$1" == "--all" ]; then
   docker cp $REAL_SRC/./ $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/
   echo "Completed copying all files from host to container"
   bin/fixowns
   bin/fixperms
 else
+  set -e
   if [ -f "$REAL_SRC/$1" ]; then
     docker cp $REAL_SRC/$1 $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$1
   else
     docker cp $REAL_SRC/$1 $(docker-compose ps -q phpfpm|awk '{print $1}'):/var/www/html/$(dirname $1)
   fi
+
   echo "Completed copying $1 from host to container"
   bin/fixowns $1
   bin/fixperms $1

--- a/compose/tests/cli.bats
+++ b/compose/tests/cli.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+load test_helpers/common.bash
+load test_helpers/running_docker.bash
+
+@test 'failing command' {
+  cd "$(magento_docker_base_path)"
+  run bin/cli ls dummydir
+  [ "$status" -ne 0 ]
+  [[ "$output" =~ "ls: cannot access 'dummydir': No such file or director" ]]
+}

--- a/compose/tests/copyfromcontainer.bats
+++ b/compose/tests/copyfromcontainer.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+DOCKER_ROOT_PATH="${BATS_TEST_DIRNAME}/.."
+
+setup_file() {
+  cd ${DOCKER_ROOT_PATH} && bin/start
+}
+
+teardown_file() {
+  cd ${DOCKER_ROOT_PATH} && bin/stop
+}
+
+@test 'copyfromcontainer show help on no arguments' {
+  cd ${DOCKER_ROOT_PATH}
+  run bin/copyfromcontainer
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "Please specify a directory or file to copy from container (ex. vendor, --all)" ]
+}

--- a/compose/tests/copyfromcontainer.bats
+++ b/compose/tests/copyfromcontainer.bats
@@ -1,17 +1,10 @@
 #!/usr/bin/env bats
 
-DOCKER_ROOT_PATH="${BATS_TEST_DIRNAME}/.."
-
-setup_file() {
-  cd ${DOCKER_ROOT_PATH} && bin/start
-}
-
-teardown_file() {
-  cd ${DOCKER_ROOT_PATH} && bin/stop
-}
+load test_helpers/common.bash
+load test_helpers/running_docker.bash
 
 @test 'copyfromcontainer show help on no arguments' {
-  cd ${DOCKER_ROOT_PATH}
+  cd $(magento_docker_base_path)
   run bin/copyfromcontainer
   [ "${status}" -eq 0 ]
   [ "${output}" = "Please specify a directory or file to copy from container (ex. vendor, --all)" ]

--- a/compose/tests/copytocontainer.bats
+++ b/compose/tests/copytocontainer.bats
@@ -4,10 +4,19 @@ DOCKER_ROOT_PATH="${BATS_TEST_DIRNAME}/.."
 DUMMY_TEST_FILE_PATH="dev/tests/test-file.txt"
 DUMMY_TEST_DIR="dev/test-dir"
 
+
+setup_file() {
+  cd ${DOCKER_ROOT_PATH} && bin/start
+}
+
 setup() {
   cd $DOCKER_ROOT_PATH
   bin/cli rm -f ${DUMMY_TEST_FILE_PATH}
   bin/cli rm -rf ${DUMMY_TEST_DIR}
+}
+
+teardown_file() {
+  cd ${DOCKER_ROOT_PATH} && bin/stop
 }
 
 @test 'copy a single file to a nested directory' {
@@ -25,5 +34,18 @@ setup() {
   touch src/${DUMMY_TEST_DIR}/file.2.txt
   run bin/copytocontainer ${DUMMY_TEST_DIR}
   run bin/cli ls ${DUMMY_TEST_DIR}
+  [ "${status}" -eq 0 ]
+}
+
+@test 'copytocontainer show help on no arguments' {
+  cd ${DOCKER_ROOT_PATH}
+  run bin/copytocontainer
+  [ "${status}" -eq 0 ]
+  [ "${output}" = "Please specify a directory or file to copy to container (ex. vendor, --all)" ]
+}
+
+@test 'copy all files to a container' {
+  cd ${DOCKER_ROOT_PATH}
+  run bin/copytocontainer --all
   [ "${status}" -eq 0 ]
 }

--- a/compose/tests/copytocontainer.bats
+++ b/compose/tests/copytocontainer.bats
@@ -1,51 +1,57 @@
 #!/usr/bin/env bats
 
-DOCKER_ROOT_PATH="${BATS_TEST_DIRNAME}/.."
-DUMMY_TEST_FILE_PATH="dev/tests/test-file.txt"
+load test_helpers/common.bash
+load test_helpers/running_docker.bash
+
+DUMMY_TEST_FILE_PATH="app/etc/test-file.txt"
+DUMMY_TEST_INVALID_DIR="dev/invalid"
 DUMMY_TEST_DIR="dev/test-dir"
 
-
-setup_file() {
-  cd ${DOCKER_ROOT_PATH} && bin/start
-}
-
 setup() {
-  cd $DOCKER_ROOT_PATH
-  bin/cli rm -f ${DUMMY_TEST_FILE_PATH}
-  bin/cli rm -rf ${DUMMY_TEST_DIR}
+  cd "$(magento_docker_base_path)"
+  bin/cli rm -f "${DUMMY_TEST_FILE_PATH}"
+  bin/cli rm -rf "${DUMMY_TEST_DIR}"
 }
 
-teardown_file() {
-  cd ${DOCKER_ROOT_PATH} && bin/stop
-}
-
-@test 'copy a single file to a nested directory' {
-  cd ${DOCKER_ROOT_PATH}
-  touch src/${DUMMY_TEST_FILE_PATH}
-  run bin/copytocontainer ${DUMMY_TEST_FILE_PATH}
-  run bin/cli ls ${DUMMY_TEST_FILE_PATH}
+@test 'copytocontainer: copy a single file to a nested directory' {
+  cd "$(magento_docker_base_path)"
+  touch "src/${DUMMY_TEST_FILE_PATH}"
+  run bin/copytocontainer "${DUMMY_TEST_FILE_PATH}"
+  run bin/cli ls -l $(dirname "${DUMMY_TEST_FILE_PATH}")
   [ "${status}" -eq 0 ]
+  [[ "${lines[@]}" =~ 'test-file.txt' ]]
 }
 
-@test 'copy a directory to a nested directory' {
-  cd ${DOCKER_ROOT_PATH}
+@test 'copytocontainer: copy a directory to a nested directory' {
+  cd "$(magento_docker_base_path)"
   mkdir -p src/${DUMMY_TEST_DIR}
   touch src/${DUMMY_TEST_DIR}/file.1.txt
   touch src/${DUMMY_TEST_DIR}/file.2.txt
   run bin/copytocontainer ${DUMMY_TEST_DIR}
-  run bin/cli ls ${DUMMY_TEST_DIR}
+  run bin/cli ls -l ${DUMMY_TEST_DIR}
+  echo "$output" >&3
   [ "${status}" -eq 0 ]
+  [[ "${lines[1]} =~ 'file.1.txt' ]]
+  [[ "${lines[2]} =~ 'file.2.txt' ]]
 }
 
-@test 'copytocontainer show help on no arguments' {
-  cd ${DOCKER_ROOT_PATH}
+@test 'copytocontainer: show help on no arguments' {
+  cd "$(magento_docker_base_path)"
   run bin/copytocontainer
   [ "${status}" -eq 0 ]
   [ "${output}" = "Please specify a directory or file to copy to container (ex. vendor, --all)" ]
 }
 
-@test 'copy all files to a container' {
-  cd ${DOCKER_ROOT_PATH}
+@test 'copytocontainer: copy all files to a container' {
+  cd "$(magento_docker_base_path)"
   run bin/copytocontainer --all
   [ "${status}" -eq 0 ]
+}
+
+@test "copytocontainer copy fails if parent directory doesn't exist" {
+  cd "$(magento_docker_base_path)"
+  mkdir -p src/${DUMMY_TEST_INVALID_DIR}
+  touch src/${DUMMY_TEST_INVALID_DIR}/test-file.txt
+  run bin/copytocontainer ${DUMMY_TEST_INVALID_DIR}/test-file.txt
+  [ "${status}" -eq 1 ]
 }

--- a/compose/tests/copytocontainer.bats
+++ b/compose/tests/copytocontainer.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+
+DOCKER_ROOT_PATH="${BATS_TEST_DIRNAME}/.."
+DUMMY_TEST_FILE_PATH="dev/tests/test-file.txt"
+DUMMY_TEST_DIR="dev/test-dir"
+
+setup() {
+  cd $DOCKER_ROOT_PATH
+  bin/cli rm -f ${DUMMY_TEST_FILE_PATH}
+  bin/cli rm -rf ${DUMMY_TEST_DIR}
+}
+
+@test 'copy a single file to a nested directory' {
+  cd ${DOCKER_ROOT_PATH}
+  touch src/${DUMMY_TEST_FILE_PATH}
+  run bin/copytocontainer ${DUMMY_TEST_FILE_PATH}
+  run bin/cli ls ${DUMMY_TEST_FILE_PATH}
+  [ "${status}" -eq 0 ]
+}
+
+@test 'copy a directory to a nested directory' {
+  cd ${DOCKER_ROOT_PATH}
+  mkdir -p src/${DUMMY_TEST_DIR}
+  touch src/${DUMMY_TEST_DIR}/file.1.txt
+  touch src/${DUMMY_TEST_DIR}/file.2.txt
+  run bin/copytocontainer ${DUMMY_TEST_DIR}
+  run bin/cli ls ${DUMMY_TEST_DIR}
+  [ "${status}" -eq 0 ]
+}

--- a/compose/tests/test_helpers/common.bash
+++ b/compose/tests/test_helpers/common.bash
@@ -1,0 +1,4 @@
+magento_docker_base_path() {
+   echo "${BATS_TEST_DIRNAME}/.."
+}
+

--- a/compose/tests/test_helpers/running_docker.bash
+++ b/compose/tests/test_helpers/running_docker.bash
@@ -1,0 +1,14 @@
+[[ ! $(type -t magento_docker_base_path)"" == 'function' ]] && echo "Run only with common.bash"
+
+setup_file() {
+  cd "$(magento_docker_base_path)" || exit 1
+  if [ ! -f src/composer.json ]; then
+    bin/download 2.4.0
+    bin/setup "magento2.test"
+  fi
+  bin/start
+}
+
+teardown_file() {
+  cd "$(magento_docker_base_path)" && bin/stop
+}


### PR DESCRIPTION
This is a teaser up for a discussion. Automated tests for scripts located in bin directory.

It `bats` in the path. Link to [bats installation](https://github.com/bats-core/bats-core/blob/v1.2.0/README.md#installation)

Tested with v1.2.0.

Installation of bats on MacOs:

```
brew install bats-core
```

From the repo root:

```
bats compose/tests
```

I've added a dump check if the docker is setup. If not it downloads m 2.4.0 and runs `bin/setup` so first run takes ages.