### PR TITLE
enable redis during setup, set backend base to admin, https for unsecure

### DIFF
--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -54,6 +54,8 @@ bin/clinotty bin/magento setup:install \
   --db-user=$MYSQL_USER \
   --db-password=$MYSQL_PASSWORD \
   --base-url=https://$BASE_URL/ \
+  --base-url-secure=https://$BASE_URL/ \
+  --backend-frontname=admin \
   --admin-firstname=John \
   --admin-lastname=Smith \
   --admin-email=john.smith@gmail.com \
@@ -67,6 +69,16 @@ bin/clinotty bin/magento setup:install \
   --amqp-user=guest \
   --amqp-password=guest \
   --amqp-virtualhost=/ \
+  --cache-backend=redis \
+  --cache-backend-redis-server=redis \
+  --cache-backend-redis-db=0 \
+  --page-cache=redis \
+  --page-cache-redis-server=redis \
+  --page-cache-redis-db=1 \
+  --session-save=redis \
+  --session-save-redis-host=redis \
+  --session-save-redis-log-level=4 \
+  --session-save-redis-db=2 \
   --search-engine=elasticsearch7 \
   --elasticsearch-host=elasticsearch \
   --use-rewrites=1
@@ -78,15 +90,6 @@ bin/clinotty bin/magento indexer:reindex
 
 echo "Forcing deploy of static content to speed up initial requests..."
 bin/clinotty bin/magento setup:static-content:deploy -f
-
-echo "Enabling Redis for cache..."
-bin/clinotty bin/magento setup:config:set --no-interaction --cache-backend=redis --cache-backend-redis-server=redis --cache-backend-redis-db=0
-
-echo "Enabling Redis for Full Page Cache..."
-bin/clinotty bin/magento setup:config:set --no-interaction  --page-cache=redis --page-cache-redis-server=redis --page-cache-redis-db=1
-
-echo "Enabling Redis for session..."
-bin/clinotty bin/magento setup:config:set --no-interaction --session-save=redis --session-save-redis-host=redis --session-save-redis-log-level=4 --session-save-redis-db=2
 
 echo "Re-indexing with Elasticsearch..."
 bin/clinotty bin/magento indexer:reindex


### PR DESCRIPTION
Refs: #283

@rangerz tips for setup.

Tested after running bin/setup:

```
Recreating compose_phpfpm_1      ... done
Recreating compose_app_1         ... done
Docker development environment setup complete.
You may now access your Magento instance at https://magento2.test/
#:~/projects/dm-redis/compose (master) $ bin/redis redis-cli monitor
OK
1598896103.038085 [0 192.168.80.7:59066] "select" "1"
1598896103.044390 [0 192.168.80.7:59068] "hget" "zc:k:69d_GLOBAL__DICONFIG" "d"
1598896103.057593 [0 192.168.80.7:59068] "hget" "zc:k:69d_DICONFIG70F9A356A11A3AEF67B14BCEDECB0F36" "d"
1598896103.062639 [0 192.168.80.7:59068] "hget" "zc:k:69d_INTERCEPTION" "d"
1598896103.074890 [0 192.168.80.7:59070] "select" "1"
```