### PR TITLE
use alpine image for redis and rabbitmq

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - dbdata:/var/lib/mysql
 
   redis:
-    image: redis:5.0
+    image: redis:5.0-alpine
 
   elasticsearch:
     image: markoshust/magento-elasticsearch:7.6.2-2
@@ -47,7 +47,7 @@ services:
       - "discovery.type=single-node"
 
   rabbitmq:
-    image: rabbitmq:3.7-management
+    image: rabbitmq:3.7-management-alpine
     ports:
       - "15672:15672"
       - "5672:5672"


### PR DESCRIPTION
Refs: #244

Use official alpine images for redis and rabbitmq. It haves about 30-40mb.
Mailhog already uses alpine.

Later I'll see if I can do something about phpfrm or nginx. It's a quick win in meantime.