### PR TITLE
fix start script on ubuntu 18.04

### DIFF
--- a/compose/bin/start
+++ b/compose/bin/start
@@ -20,7 +20,7 @@ function parseYaml {
     if (length($3) > 0) {
       vn=""; for (i=0; i<indent; i++) {vn = (vn)(vname[i])("_")}
       if ("'$2'_" == vn) {
-         print substr($3 ,0 , match($3,":")-1)
+         print substr($3 ,1 , match($3,":")-1)
       }
     }
   }'


### PR DESCRIPTION
fixes #309

```
substr(string, start [, length ])
If start is less than one, substr() treats it as if it was one. (POSIX doesn’t specify what to do in this case: BWK awk acts this way, and therefore gawk does too.) If start is greater than the number of characters in the string, substr() returns the null string. Similarly, if length is present but less than or equal to zero, the null string is returned.
```

Apparently Ubuntu 18.04 had an older version of awk which didn't handle above the same way.