### PR TITLE
Optimize fixperms by using one find loop and passing all paths in one go

### DIFF
--- a/compose/bin/fixperms
+++ b/compose/bin/fixperms
@@ -2,12 +2,10 @@
 echo "Correcting filesystem permissions..."
 
 if [ -z "$1" ]; then
-  bin/clinotty find var vendor pub/static pub/media app/etc -type f -exec chmod u+w {} \;
-  bin/clinotty find var vendor pub/static pub/media app/etc -type d -exec chmod u+w {} \;
+  bin/clinotty find var vendor pub/static pub/media app/etc \( -type f -or -type d \) -exec chmod u+w {} +;
   bin/clinotty chmod u+x bin/magento
 else
-  bin/clinotty find $1 -type f -exec chmod u+w {} \;
-  bin/clinotty find $1 -type d -exec chmod u+w {} \;
+  bin/clinotty find "$1" \( -type f -or -type d \) -exec chmod u+w {} +;
 fi
 
 echo "Filesystem permissions corrected."


### PR DESCRIPTION
instead of one by one

Old:
```
Correcting filesystem permissions...
Filesystem permissions corrected.

real	1m54.605s
user	0m1.414s
sys	0m0.316s
```

New:
```
Correcting filesystem permissions...
Filesystem permissions corrected.
real	0m3.418s
user	0m0.945s
sys	0m0.231s
```

You can change `chmod` to `echo` to see the difference in the returned output. 
All paths are passed in one go to chmod instead of running it one by one on each file.

Similar command is used now in Magento 2 docs: https://devdocs.magento.com/guides/v2.4/config-guide/prod/prod_file-sys-perms.html#Production-file-system-ownership-for-shared-hosting-one-user-