### PR TITLE
mkcert -install is being called in the wrong place

### DIFF
--- a/compose/bin/setup-ssl
+++ b/compose/bin/setup-ssl
@@ -1,7 +1,10 @@
 #!/bin/bash
 [ -z "$1" ] && echo "Please specify a domain (ex. mydomain.test)" && exit
 
-# Generate certificate authority if not already setup
+# Generate a new local CA "/root/.local/share/mkcert"
+docker-compose exec -T -u root app mkcert -install
+
+# Read the CA install for requested hostname
 if ! docker-compose exec -T -u root app cat /root/.local/share/mkcert/rootCA.pem | grep -q 'BEGIN CERTIFICATE'; then
   bin/setup-ssl-ca
 fi

--- a/compose/bin/setup-ssl-ca
+++ b/compose/bin/setup-ssl-ca
@@ -1,5 +1,5 @@
 #!/bin/bash
-docker-compose exec -T -u root app mkcert -install
+
 docker cp $(docker-compose ps -q app|awk '{print $1}'):/root/.local/share/mkcert/rootCA.pem .
 echo "System password requested to install certificate authority on host..."
 


### PR DESCRIPTION
In bin/setup-ssl 
There is no CA file to read  in order to call bin/setup-ssl-ca. You must create it first.

In bin/setup-ssl-ca
The `mkcert -install` is in the wrong place, the statement will never be reached unless the CA is already there.