### PR TITLE
Update nodejs to latest LTS

### DIFF
--- a/images/php/7.3/Dockerfile
+++ b/images/php/7.3/Dockerfile
@@ -76,7 +76,7 @@ RUN groupadd -g 1000 app \
  && useradd -g 1000 -u 1000 -d /var/www -s /bin/bash app
 
 RUN apt-get install -y gnupg \
-  && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+  && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && apt-get install -y nodejs \
   && mkdir /var/www/.config /var/www/.npm \
   && chown app:app /var/www/.config /var/www/.npm \

--- a/images/php/7.4/Dockerfile
+++ b/images/php/7.4/Dockerfile
@@ -76,7 +76,7 @@ RUN groupadd -g 1000 app \
  && useradd -g 1000 -u 1000 -d /var/www -s /bin/bash app
 
 RUN apt-get install -y gnupg \
-  && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+  && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && apt-get install -y nodejs \
   && mkdir /var/www/.config /var/www/.npm \
   && chown app:app /var/www/.config /var/www/.npm \

--- a/images/php/8.0/Dockerfile
+++ b/images/php/8.0/Dockerfile
@@ -55,7 +55,7 @@ RUN groupadd -g 1000 app \
  && useradd -g 1000 -u 1000 -d /var/www -s /bin/bash app
 
 RUN apt-get install -y gnupg \
-  && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+  && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
   && apt-get install -y nodejs \
   && mkdir /var/www/.config /var/www/.npm \
   && chown app:app /var/www/.config /var/www/.npm \


### PR DESCRIPTION
I am using this awesome docker configuration for developing ScandiPWA theme for Magento 2.
And it requires node version higher than 12.x.x.
And also currently used node version (10) run to it's end of life ([2021-04-30](https://nodejs.org/en/about/releases/)) 
So, I'm proposing upgrade node version.