### PR TITLE
Change in note for linux users

### DIFF
--- a/compose/docker-compose.dev.yml
+++ b/compose/docker-compose.dev.yml
@@ -22,7 +22,7 @@ services:
       #- ./src/var/report:/var/www/html/var/report:cached
       # To sync your SSH to the container, uncomment the following line:
       #- ~/.ssh/id_rsa:/var/www/.ssh/id_rsa:cached
-      # Linux only: remove the above lines and mount the entire src directory with:
+      # Linux only: remove the above lines (except nginx.conf line) and mount the entire src directory with:
       #- ./src:/var/www/html:cached
 
   phpfpm:


### PR DESCRIPTION
As mentioned by @vy-shmal [here](https://github.com/markshust/docker-magento/issues/405#issuecomment-776029611), if we comment nginx.conf line, we don't get Magento's nginx configuration, causing 403 error.