### PR TITLE
Add setup-domain command

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,9 +178,6 @@ bin/download 2.4.2
 # bin/cli git clone git@github.com:magento/magento2.git .
 # bin/cli git checkout 2.4-develop
 
-# Create a DNS host entry for the site:
-echo "127.0.0.1 ::1 magento.test" | sudo tee -a /etc/hosts
-
 # Run the setup installer for Magento:
 bin/setup magento.test
 
@@ -197,9 +194,6 @@ curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/te
 cp -R ~/Sites/existing src
 # or: git clone git@github.com:myrepo.git src
 
-# Create a DNS host entry for the site:
-echo "127.0.0.1 ::1 yoursite.test" | sudo tee -a /etc/hosts
-
 # Start some containers, copy files to them and then restart the containers:
 docker-compose -f docker-compose.yml up -d
 bin/copytocontainer --all ## Initial copy will take a few minutes...
@@ -214,9 +208,8 @@ bin/mysql < backups/magento.sql
 # Import app-specific environment settings:
 bin/magento app:config:import
 
-# Set base URLs to local environment URL (if not defined in env.php file):
-bin/magento config:set web/secure/base_url https://yoursite.test/
-bin/magento config:set web/unsecure/base_url https://yoursite.test/
+# Create a DNS host entry and setup Magento base url
+bin/setup-domain yoursite.test
 
 bin/restart
 
@@ -270,6 +263,7 @@ It is recommended to keep your root docker config files in one repository, and y
 - `bin/rootnotty`: Run any CLI command as root with no TTY. Ex `bin/rootnotty chown -R app:app /var/www/html`
 - `bin/setup`: Run the Magento setup process to install Magento from the source code, with optional domain name. Defaults to `magento.test`. Ex. `bin/setup magento.test`
 - `bin/setup-composer-auth`: Setup authentication credentials for Composer.
+- `bin/setup-domain`: Setup Magento domain name. Ex: `bin/setup-domain magento.test`
 - `bin/setup-grunt`: Install and configure Grunt JavaScript task runner to compile .less files
 - `bin/setup-pwa-studio`: (BETA) Install PWA Studio (requires NodeJS and Yarn to be installed on the host machine). Pass in your base site domain, otherwise the default `master-7rqtwti-mfwmkrjfqvbjk.us-4.magentosite.cloud` will be used. Ex: `bin/setup-pwa-studio magento.test`
 - `bin/setup-ssl`: Generate an SSL certificate for one or more domains. Ex. `bin/setup-ssl magento.test foo.test`

--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -6,7 +6,7 @@ source env/db.env
 # shellcheck source=../env/magento.env
 source env/magento.env
 
-BASE_URL=${1:-magento2.test}
+DOMAIN=${1:-magento.test}
 ES_HOST=elasticsearch
 ES_PORT=9200
 
@@ -31,8 +31,8 @@ bin/clinotty bin/magento setup:install \
   --db-name="$MYSQL_DATABASE" \
   --db-user="$MYSQL_USER" \
   --db-password="$MYSQL_PASSWORD" \
-  --base-url=https://"$BASE_URL"/ \
-  --base-url-secure=https://"$BASE_URL"/ \
+  --base-url=https://"$DOMAIN"/ \
+  --base-url-secure=https://"$DOMAIN"/ \
   --backend-frontname="$MAGENTO_ADMIN_FRONTNAME" \
   --admin-firstname="$MAGENTO_ADMIN_FIRST_NAME" \
   --admin-lastname="$MAGENTO_ADMIN_LAST_NAME" \
@@ -74,11 +74,11 @@ bin/clinotty bin/magento setup:static-content:deploy -f
 echo "Re-indexing with Elasticsearch..."
 bin/clinotty bin/magento indexer:reindex
 
+echo "Setting basic URL and generating SSL certificate..."
+bin/setup-domain "${DOMAIN}"
+
 echo "Clearing the cache to apply updates..."
 bin/clinotty bin/magento cache:flush
 
-echo "Generating SSL certificate..."
-bin/setup-ssl "$BASE_URL"
-
 echo "Docker development environment setup complete."
-echo "You may now access your Magento instance at https://${BASE_URL}/"
+echo "You may now access your Magento instance at https://${DOMAIN}/"

--- a/compose/bin/setup-domain
+++ b/compose/bin/setup-domain
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o errexit
+
+[ -z "$1" ] && echo "Please specify a domain name (ex. magento.test)" && exit
+
+DOMAIN=$1
+
+echo "Your system password has been requested to add an entry to /etc/hosts..."
+echo "127.0.0.1 ::1 $DOMAIN" | sudo tee -a /etc/hosts
+
+echo "Set https://${DOMAIN}/ to web/secure/base_url and web/secure/base_url"
+bin/magento config:set web/secure/base_url https://"$DOMAIN"/
+bin/magento config:set web/unsecure/base_url https://"$DOMAIN"/
+
+echo "Generating SSL certificate..."
+bin/setup-ssl "$DOMAIN"

--- a/lib/onelinesetup
+++ b/lib/onelinesetup
@@ -7,8 +7,6 @@ EDITION=${3:-community}
 
 curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/template | bash
 
-# &&'s are used below otherwise onelinesetup script fails/errors on bin/download
-bin/download "${VERSION}" "${EDITION}" \
-  && echo "Your system password has been requested to add an entry to /etc/hosts..." \
-  && echo "127.0.0.1 ::1 $DOMAIN" | sudo tee -a /etc/hosts \
-  && bin/setup $DOMAIN
+bin/download "${VERSION}" "${EDITION}"
+
+bin/setup ${DOMAIN}


### PR DESCRIPTION
`setup-domain` include setup host file, magento baseUrl config,  and SSL certificate.

It can change the URL at any time, including install steps finished.