### PR TITLE
Updated text in fixowns & fixperms

### DIFF
--- a/compose/bin/fixowns
+++ b/compose/bin/fixowns
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo "Correcting filesystem ownerships..."
+echo "Fixing filesystem ownerships..."
 
 if [ -z "$1" ]; then
   bin/rootnotty chown -R app:app /var/www/
@@ -7,4 +7,4 @@ else
   bin/rootnotty chown -R app:app /var/www/html/"$1"
 fi
 
-echo "Filesystem ownerships corrected."
+echo "Filesystem ownerships fixed."

--- a/compose/bin/fixperms
+++ b/compose/bin/fixperms
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo "Correcting filesystem permissions..."
+echo "Fixing filesystem permissions..."
 
 if [ -z "$1" ]; then
   bin/clinotty find var vendor pub/static pub/media app/etc \( -type f -or -type d \) -exec chmod u+w {} +;
@@ -8,4 +8,4 @@ else
   bin/clinotty find "$1" \( -type f -or -type d \) -exec chmod u+w {} +;
 fi
 
-echo "Filesystem permissions corrected."
+echo "Filesystem permissions fixed."


### PR DESCRIPTION
Updated text in the above bash files to reflect the command name. `fixowns` will "fix" ownerships instead of "correcting" them. Similarly with `fixperms`