### PR TITLE
Added Elasticsearch support for ARM environments

### DIFF
--- a/compose/docker-compose.arm.yml
+++ b/compose/docker-compose.arm.yml
@@ -1,0 +1,12 @@
+# Mark Shust's Docker Configuration for Magento
+# (https://github.com/markshust/docker-magento)
+#
+# Include this configuration file for ARM environments.
+#
+# Version 38.0.0
+
+version: "3"
+
+services:
+  elasticsearch:
+    image: markoshust/magento-elasticsearch:7.9

--- a/images/elasticsearch/7.9/Dockerfile
+++ b/images/elasticsearch/7.9/Dockerfile
@@ -1,0 +1,4 @@
+FROM elasticsearch:7.9.3
+
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-icu
+RUN /usr/share/elasticsearch/bin/elasticsearch-plugin install analysis-phonetic


### PR DESCRIPTION
### CHANGELOG

#### ADDED

- Elasticsearch Docker image for `v7.9.3`
- A new Compose file with custom/necessary configuration for ARM environments. This PR adds content to this file to force `v7.9.x` for ARM environments.

### Notes

- Elasticsearch `7.9.x` needs a minimum Magento version of `~2.3.7` or `~2.4.2` for official Magento tested support (https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html)
- The new image needs to be built and published to Docker Hub
- Need to figure out on how to possibly automate the inclusion of the ARM Compose file if the `docker-compose up` command is run on an ARM environment.
- The ARM Compose file can be reused to send environment variables for other images (upcoming PRs). For example, we need to switch the `mkcert` and `ioncube` package architectures inside the Dockerfile for cross-compatibility