### PR TITLE
Replace Percona DB with MariaDB 10.4

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     volumes: *appvolumes
 
   db:
-    image: percona:5.7
+    image: mariadb:10.4
     command: --max_allowed_packet=64M
     ports:
       - "3306:3306"


### PR DESCRIPTION
### CHANGELOG

#### MODIFIED

- DB from Percona `5.7` to Maria DB `10.4` which has [multi-arch support](https://hub.docker.com/_/mariadb?tab=tags&page=1&ordering=last_updated&name=10.4)

Closes #499 