### PR TITLE
[ARM Support] Added logic to make Nginx image cross-platform

### DIFF
--- a/images/nginx/1.18/Dockerfile
+++ b/images/nginx/1.18/Dockerfile
@@ -14,9 +14,11 @@ RUN apk add --no-cache \
 RUN mkdir /etc/nginx/certs \
   && echo -e "\n\n\n\n\n\n\n" | openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /etc/nginx/certs/nginx.key -out /etc/nginx/certs/nginx.crt
 
+ARG TARGETARCH
+ENV TARGETARCH=${TARGETARCH:-amd64}
 RUN ( \
   cd /usr/local/bin/ \
-  && curl -L https://github.com/FiloSottile/mkcert/releases/download/v1.4.1/mkcert-v1.4.1-linux-amd64 -o mkcert \
+  && curl -L https://github.com/FiloSottile/mkcert/releases/download/v1.4.3/mkcert-v1.4.3-linux-$TARGETARCH -o mkcert \
   && chmod +x mkcert \
   )
 


### PR DESCRIPTION
### CHANGELOG

#### ADDED

- Cross-platform Nginx build

### Notes

- [Docker platform args](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope). We can use the `TARGETARCH` argument to get `amd64` or `arm64`. I'm not very sure about this yet so this needs to be tested in multiple platoforms to ensure only one of these two values are generated.
- `ENV TARGETARCH=${TARGETARCH:-amd64}` is used for fallback in case [Docker BuildKit](https://docs.docker.com/engine/reference/builder/#buildkit) isn't used. If it's used while building, we can remove this line. (ref: https://github.com/docker/buildx/issues/510)
- If we can proceed with using these args, we don't need an ARM Compose file for this PR. Same case for the PHP image. In such a case, we don't need to have an ARM Compose file just to define a minimum version (`7.9`) of Elasticsearch for ARM environments. (https://github.com/markshust/docker-magento/pull/513)