### PR TITLE
Make uid & gid of app user configurable

### DIFF
--- a/images/php/7.3/Dockerfile
+++ b/images/php/7.3/Dockerfile
@@ -1,6 +1,8 @@
 FROM php:7.3-fpm-buster
 MAINTAINER Mark Shust <mark@shust.com>
 
+ARG COMPOSE_USER=1000
+
 RUN apt-get update && apt-get install -y \
   cron \
   git \
@@ -71,8 +73,8 @@ RUN curl -o /tmp/ssh2-1.2.tgz https://pecl.php.net/get/ssh2 \
 #RUN pecl install ssh2-1.2 \
 #  && docker-php-ext-enable ssh2
 
-RUN groupadd -g 1000 app \
- && useradd -g 1000 -u 1000 -d /var/www -s /bin/bash app
+RUN groupadd -g "$COMPOSE_USER" app \
+  && useradd -g "$COMPOSE_USER" -u "$COMPOSE_USER" -d /var/www -s /bin/bash app
 
 RUN apt-get install -y gnupg \
   && curl -sL https://deb.nodesource.com/setup_14.x | bash - \

--- a/images/php/7.4/Dockerfile
+++ b/images/php/7.4/Dockerfile
@@ -1,6 +1,8 @@
 FROM php:7.4-fpm-buster
 MAINTAINER Mark Shust <mark@shust.com>
 
+ARG COMPOSE_USER=1000
+
 RUN apt-get update && apt-get install -y \
   cron \
   git \
@@ -71,8 +73,8 @@ RUN curl -o /tmp/ssh2-1.2.tgz https://pecl.php.net/get/ssh2 \
 #RUN pecl install ssh2-1.2 \
 #  && docker-php-ext-enable ssh2
 
-RUN groupadd -g 1000 app \
- && useradd -g 1000 -u 1000 -d /var/www -s /bin/bash app
+RUN groupadd -g "$COMPOSE_USER" app \
+  && useradd -g "$COMPOSE_USER" -u "$COMPOSE_USER" -d /var/www -s /bin/bash app
 
 RUN apt-get install -y gnupg \
   && curl -sL https://deb.nodesource.com/setup_14.x | bash - \

--- a/images/php/8.0/Dockerfile
+++ b/images/php/8.0/Dockerfile
@@ -1,6 +1,8 @@
 FROM php:8.0-fpm-buster
 MAINTAINER Mark Shust <mark@shust.com>
 
+ARG COMPOSE_USER=1000
+
 RUN apt-get update && apt-get install -y \
   cron \
   default-mysql-client \
@@ -51,8 +53,8 @@ RUN pecl channel-update pecl.php.net \
 RUN docker-php-ext-enable xdebug \
   && sed -i -e 's/^zend_extension/\;zend_extension/g' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
-RUN groupadd -g 1000 app \
- && useradd -g 1000 -u 1000 -d /var/www -s /bin/bash app
+RUN groupadd -g "$COMPOSE_USER" app \
+  && useradd -g "$COMPOSE_USER" -u "$COMPOSE_USER" -d /var/www -s /bin/bash app
 
 RUN apt-get install -y gnupg \
   && curl -sL https://deb.nodesource.com/setup_14.x | bash - \


### PR DESCRIPTION
This makes the user id & group id of the app user configurable during docker build.

Some of our developers have a different user id & group id on the host than the default of 1000 used in the build. This causes permission problems when mounting volumes from the host in the container. This PR fixes this by making the user id & group id configurable during the build process.

The downside of this: Since this is a build setting, the users have to build their own image and cannot use the default one provided by you.

When you are building the images nothing changes as the user id & group id of 1000 is used as a fallback when no id is provided during docker build.

If you want to change the id during build you need to execute the following command:
```
docker build --build-arg COMPOSE_USER=1234 .
```

Also, docker-compose seems to support build args:
```
docker-compose build --build-arg COMPOSE_USER=1234
```

Not sure if this PR makes sense but at least it gives users an option when running into permission problems due to mismatching id's on the host and in the container.