### PR TITLE
Support XDebug 3 on bin/n98-magerun2

### DIFF
--- a/compose/bin/n98-magerun2
+++ b/compose/bin/n98-magerun2
@@ -11,4 +11,10 @@ if ! bin/cliq ls bin/n98-magerun2.phar; then
   bin/cliq mv n98-magerun2.phar bin
 fi
 
-bin/cli bin/n98-magerun2.phar "$@"
+S=$(bin/cli cat /usr/local/etc/php/php.ini | grep -iGc 'xdebug.mode = off');
+
+if [[ $S == 1 ]]; then
+  bin/cli bin/n98-magerun2.phar "$@"
+else
+  bin/cli php -dxdebug.mode=debug -dxdebug.start_with_request=yes bin/n98-magerun2.phar "$@"
+fi


### PR DESCRIPTION
I struggled to use XDebug 3 to debug a job I've created using `bin/n98-magerun2 sys:cron:run jobname`.
The `bin/xdebug enable` was not enough.
This would do the trick (solve the problem) when combined to environment > PHP_IDE_CONFIG at docker-compose.dev.yml and the correct configuration in phpstorm (as shown below):

<img width="994" alt="image" src="https://user-images.githubusercontent.com/191149/137431980-442461d4-2d10-4b3e-85b0-4ac1ab5ff41c.png">
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/191149/137432057-6ac821dd-a6be-440d-94d4-c5518db5a797.png">
