### PR TITLE
Updated onelinesetup to use 2.4.3-p1 by default

### DIFF
--- a/lib/onelinesetup
+++ b/lib/onelinesetup
@@ -2,7 +2,7 @@
 set -o errexit
 
 DOMAIN=${1:-magento.test}
-VERSION=${2:-2.4.3}
+VERSION=${2:-2.4.3-p1}
 EDITION=${3:-community}
 
 curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/template | bash


### PR DESCRIPTION
For consistency with https://github.com/markshust/docker-magento/commit/9b1486acd435c9d9a1c1b0bc21da1be3cad57387! :) 