### PR TITLE
549 - Improved selenium configuration for MFTF

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ To work with MFTF you will need to first enable the `selenium` image in the `doc
 1. Run mftf build process `bin/mftf build:project`. This should build the basic setup for mftf in your project.
 2. Update the `extra_host` values to match your Magento URL and IP in `docker-compose.dev.yml`.
 3. Update the values in `src/dev/tests/acceptance/.env`, including adding the new line `SELENIUM_HOST=selenium` to define the host Codeception should connect to.
-4. Run a sample test `bin/mftf run:test AdminLoginTest`.
+4. Run a sample test `bin/mftf run:test AdminLoginSuccessfulTest`.
 5. Update your `nginx.conf` file to allow access to the dev section with the following, before the final `deny all` section:
 
 ```
@@ -473,8 +473,10 @@ location ~* ^/dev/tests/acceptance/utils($|/) {
 
 For debugging, you can connect to the selenium image using a VCN client.
 
-- Connect with the VCN option and `127.0.0.1:5900`
+- Connect with the VCN option and `127.0.0.1:5900`, (default password: `secret`)
 - Run `bin/mftf doctor` to validate all sections are setup correctly.
+
+Find more info [here](https://devdocs.magento.com/mftf/docs/getting-started.html) about mftf configuration.
 
 ## Credits
 

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -23,11 +23,17 @@ services:
       - sockdata:/sock
       - ssldata:/etc/nginx/certs
 
+  ## extra_hosts is required for selenium
+  ## For extra_hosts, replace "magento.test" with the URL of your site,
+  ## and also replace 172.17.0.1 with the result of:
+  ## docker run --rm alpine ip route | awk 'NR==1 {print $3}'
   phpfpm:
     image: markoshust/magento-php:7.4-fpm-10
     links:
       - db
     volumes: *appvolumes
+  #  extra_hosts:
+  #    - "magento.test:172.17.0.1"
 
   db:
     image: mariadb:10.4


### PR DESCRIPTION
This MR fixes issue #549 

I tested it locally with version 40.0.0.

Add:
- default password for selenium in VCN
- added link to configuration for MFTF

Fix:
- sample test name in the readme
- extra_hosts for phpfpm container to run mftf there