### PR TITLE
fix-not-tty-error-on-linux

### DIFF
--- a/compose/bin/setup-ssl
+++ b/compose/bin/setup-ssl
@@ -2,7 +2,7 @@
 [ -z "$1" ] && echo "Please specify a domain (ex. mydomain.test)" && exit
 
 # Generate certificate authority if not already setup
-if ! docker-compose exec -T -u root app cat /root/.local/share/mkcert/rootCA.pem | grep -q 'BEGIN CERTIFICATE'; then
+if ! docker-compose exec -u root app cat /root/.local/share/mkcert/rootCA.pem | grep -q 'BEGIN CERTIFICATE'; then
   bin/setup-ssl-ca
 fi
 


### PR DESCRIPTION
Fixes error encountered on Linux that causes docker error "_The input device is not a TTY_" and prevents online installation.