### PR TITLE
update redis

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     extra_hosts: *appextrahosts
 
   redis:
-    image: redis:5.0-alpine
+    image: redis:6.0-alpine
     ports:
       - "6379:6379"
     extra_hosts: *appextrahosts


### PR DESCRIPTION
Update redis container because it's listed in [System requirements](https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html).