### PR TITLE
Lock base_url in env.php

### DIFF
--- a/compose/bin/setup-domain
+++ b/compose/bin/setup-domain
@@ -9,8 +9,8 @@ echo "Your system password has been requested to add an entry to /etc/hosts..."
 echo "127.0.0.1 ::1 $DOMAIN" | sudo tee -a /etc/hosts
 
 echo "Set https://${DOMAIN}/ to web/secure/base_url and web/secure/base_url"
-bin/clinotty bin/magento config:set web/secure/base_url https://"$DOMAIN"/
-bin/clinotty bin/magento config:set web/unsecure/base_url https://"$DOMAIN"/
+bin/clinotty bin/magento config:set --lock-env web/secure/base_url https://"$DOMAIN"/
+bin/clinotty bin/magento config:set --lock-env web/unsecure/base_url https://"$DOMAIN"/
 
 echo "Generating SSL certificate..."
 bin/setup-ssl "$DOMAIN"


### PR DESCRIPTION
I think sensitive data like the base_url should not be editable and therefore belongs into env.php