### PR TITLE
Update setup with no interaction

### DIFF
--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -72,7 +72,8 @@ bin/clinotty bin/magento setup:install \
   --search-engine=elasticsearch7 \
   --elasticsearch-host=$ES_HOST \
   --elasticsearch-port=$ES_PORT \
-  --use-rewrites=1
+  --use-rewrites=1 \
+  --no-interaction
 
 echo "Copying files from container to host after install..."
 bin/copyfromcontainer --all


### PR DESCRIPTION
The setup is ran within the container, so interaction is not possible.
To not block the setup, --no-interaction should be added.

For example, if an existing project with stores in the config.php get's installed with a clean database, Magento will ask if it should create those store views as well.
The no-interaction defaults to yes in this case.