### PR TITLE
Enable WebP support in GD

### DIFF
--- a/images/php/7.4/Dockerfile
+++ b/images/php/7.4/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
   libfreetype6-dev \
   libicu-dev \
   libjpeg62-turbo-dev \
+  libwebp-dev \
   libmcrypt-dev \
   libonig-dev \
   libpng-dev \
@@ -24,7 +25,7 @@ RUN apt-get update && apt-get install -y \
   zip \
   procps
 
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp
 
 RUN docker-php-ext-install \
   bcmath \

--- a/images/php/8.1/Dockerfile
+++ b/images/php/8.1/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
   libbz2-dev \
   libfreetype6-dev \
   libicu-dev \
+  libwebp-dev \
   libjpeg62-turbo-dev \
   libmcrypt-dev \
   libonig-dev \
@@ -24,7 +25,7 @@ RUN apt-get update && apt-get install -y \
   vim \
   zip
 
-RUN docker-php-ext-configure gd --with-freetype --with-jpeg
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp
 
 RUN docker-php-ext-install \
   bcmath \


### PR DESCRIPTION
Enable WebP support in GD

For 7.3 and below the line:

```
RUN docker-php-ext-configure \
  gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/

```
should become:

```
RUN docker-php-ext-configure \
  gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include/

```