### PR TITLE
fix: prevent /etc/hosts domain duplication

### DIFF
--- a/compose/bin/setup-domain
+++ b/compose/bin/setup-domain
@@ -5,8 +5,10 @@ set -o errexit
 
 DOMAIN=$1
 
-echo "Your system password has been requested to add an entry to /etc/hosts..."
-echo "127.0.0.1 ::1 $DOMAIN" | sudo tee -a /etc/hosts
+if ! grep -q $DOMAIN /etc/hosts; then
+    echo "Your system password is needed to add an entry to /etc/hosts..."
+    echo "127.0.0.1 ::1 $DOMAIN" | sudo tee -a /etc/hosts
+fi
 
 echo "Set https://${DOMAIN}/ to web/secure/base_url and web/secure/base_url"
 bin/clinotty bin/magento config:set web/secure/base_url https://"$DOMAIN"/

--- a/compose/bin/setup-domain
+++ b/compose/bin/setup-domain
@@ -5,7 +5,7 @@ set -o errexit
 
 DOMAIN=$1
 
-if ! grep -q $DOMAIN /etc/hosts; then
+if ! grep -q "$DOMAIN" /etc/hosts; then
     echo "Your system password is needed to add an entry to /etc/hosts..."
     echo "127.0.0.1 ::1 $DOMAIN" | sudo tee -a /etc/hosts
 fi


### PR DESCRIPTION
Small patch to add the domain into _/etc/hosts_ only if it isn't already there