### PR TITLE
bin/update: rsync ignore timestamp

### DIFF
--- a/compose/bin/update
+++ b/compose/bin/update
@@ -3,7 +3,7 @@ set -o errexit
 mkdir -p tmpupdate && cd "$_"
 curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/template | bash
 rm -rf .git
-rsync -av ./ ../
+rsync -av --checksum ./ ../
 cd ..
 rm -rf tmpupdate
 echo "docker-magento has been updated, run bin/restart to apply the updates"


### PR DESCRIPTION
When calling `bin/update` the `rsync` call should only update actually changed files. Currently all files are overwritten because the files in `tmpupdate` will have newer timestamps. Thus disabling timestamp comparisons and adding checksumming. This shouldn't impact rsync performance since there are no large binaries in the repo. 

For more info see: https://stackoverflow.com/a/44353773/1238689