### PR TITLE
Magento 2.4.4 as default

### DIFF
--- a/lib/onelinesetup
+++ b/lib/onelinesetup
@@ -2,7 +2,7 @@
 set -o errexit
 
 DOMAIN=${1:-magento.test}
-VERSION=${2:-2.4.3-p1}
+VERSION=${2:-2.4.4}
 EDITION=${3:-community}
 
 curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/template | bash


### PR DESCRIPTION
Since we have new patch versions and the new stable version 2.4.4 working fine. I think it's relevant to update it.
What do you think? I can change it to p3 in case you don't want the lasted version as default.