### PR TITLE
Fix user string interpreted as regex

### DIFF
--- a/compose/bin/start
+++ b/compose/bin/start
@@ -43,7 +43,7 @@ IS_VALID=true
 
 # Loop through all files missing from the docker-compose.dev.yml file
 for file in $VOLUME_LIST; do
-  if [ ! -e "$file" ] && [[ ! " $IGNORE_LIST " =~ $file ]]; then
+  if [[ ! -e $file && " $IGNORE_LIST " != *" $file "* ]]; then
     echo "$file: No such file or directory"
     IS_VALID=false
   fi


### PR DESCRIPTION
This was causing issues if the volume mapped contained regex metacharacters, e.g. periods:

```sh
file='/src/p...hes'
file2='/src/patches'
IGNORE_LIST='/src/patches /src/foo'
[[ " $IGNORE_LIST " =~ $file ]] # returns true (shouldn't)
[[ " $IGNORE_LIST " =~ $file2 ]] # returns true
```
Included fix, using globs instead:
```sh
[[ " $IGNORE_LIST " = *" $file "* ]] # returns false
[[ " $IGNORE_LIST " = *" $file2 "* ]] # returns true
```

`= <glob>` is also safer than `=~ <regex>` with arbitrary user strings, but in this case, it's actually more correct.