### PR TITLE
chore: add debug scripts for bin/magento and magerun2

### DIFF
--- a/compose/bin/debug-magento
+++ b/compose/bin/debug-magento
@@ -1,0 +1,2 @@
+#!/bin/bash
+bin/cli php -dxdebug.mode=debug -dxdebug.start_with_request=yes bin/magento "$@"

--- a/compose/bin/debug-n98-magerun2
+++ b/compose/bin/debug-n98-magerun2
@@ -1,0 +1,2 @@
+#!/bin/bash
+bin/cli php -dxdebug.mode=debug -dxdebug.start_with_request=yes bin/n98-magerun2.phar "$@"


### PR DESCRIPTION
These two scripts allow us to execute CLI commands and invoke the xdebug debugger while doing so.
Especially useful for debugging cronjobs via bin/debug-n98-magerun2 sys:cron:run.