### PR TITLE
Support OpenSearch for search engine

### DIFF
--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -7,8 +7,8 @@ MEM=$(docker info | grep "Total Memory" | cut -d':' -f2 | xargs | sed s/GiB//)
 
 # shellcheck source=../env/db.env
 source env/db.env
-# shellcheck source=../env/elasticsearch.env
-source env/elasticsearch.env
+# shellcheck source=../env/opensearch.env
+source env/opensearch.env
 # shellcheck source=../env/magento.env
 source env/magento.env
 # shellcheck source=../env/rabbitmq.env
@@ -61,8 +61,8 @@ bin/clinotty bin/magento setup:install \
   --session-save-redis-log-level=4 \
   --session-save-redis-db=2 \
   --search-engine=elasticsearch7 \
-  --elasticsearch-host=$ES_HOST \
-  --elasticsearch-port=$ES_PORT \
+  --elasticsearch-host=$OS_HOST \
+  --elasticsearch-port=$OS_PORT \
   --use-rewrites=1 \
   --no-interaction
 

--- a/compose/docker-compose.healthcheck.yml
+++ b/compose/docker-compose.healthcheck.yml
@@ -14,7 +14,7 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-      elasticsearch:
+      opensearch:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
@@ -33,9 +33,9 @@ services:
       timeout: 5s
       retries: 30
 
-  elasticsearch:
+  opensearch:
     healthcheck:
-      test: 'curl --fail elasticsearch:9200/_cat/health >/dev/null || exit 1'
+      test: 'curl --fail opensearch:9200/_cat/health >/dev/null || exit 1'
       interval: 5s
       timeout: 5s
       retries: 30

--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -52,19 +52,20 @@ services:
     ports:
       - "6379:6379"
 
-  elasticsearch:
-    image: markoshust/magento-elasticsearch:7.16-0
+  opensearch:
+    image: markoshust/magento-opensearch:1.2.4-0
     ports:
       - "9200:9200"
       - "9300:9300"
     environment:
-      - "discovery.type=single-node"
+      - discovery.type=single-node
+      - DISABLE_SECURITY_PLUGIN=true
       ## Set custom heap size to avoid memory errors
-      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g"
       ## Avoid test failures due to small disks
       ## More info at https://github.com/markshust/docker-magento/issues/488
-      - "cluster.routing.allocation.disk.threshold_enabled=false"
-      - "index.blocks.read_only_allow_delete"
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - index.blocks.read_only_allow_delete
 
   rabbitmq:
     image: markoshust/magento-rabbitmq:3.9-0

--- a/compose/env/opensearch.env
+++ b/compose/env/opensearch.env
@@ -1,0 +1,2 @@
+OS_HOST=opensearch
+OS_PORT=9200

--- a/images/opensearch/1.2/Dockerfile
+++ b/images/opensearch/1.2/Dockerfile
@@ -1,0 +1,5 @@
+FROM opensearchproject/opensearch:1.2.4
+
+RUN /usr/share/opensearch/bin/opensearch-plugin install --batch \
+  analysis-icu \
+  analysis-phonetic


### PR DESCRIPTION
Support opensearch for Magento 2.4.4 up

opensearch setting: (Not sure if needed)
```
opensearch:
    ulimits:
      memlock:
        soft: -1
        hard: -1
    environment:
      - bootstrap.memory_lock=true
```

TODOs: (**won't finish on this pull request**)
- create`markoshust/magento-opensearch:1.2.4-0` for dockerhub image
- `.github/workflows/build-elasticsearch.yml` for test
- `README.md` content update
- ElasticSearch backward compatible
- `./compose/template/dev/tests/integration/etc/install-config-mysql.php.2.4.dist`