### PR TITLE
Use OPENSEARCH_JAVA_OPTS for opensearch

### DIFF
--- a/compose/env/opensearch.env
+++ b/compose/env/opensearch.env
@@ -3,7 +3,7 @@ OPENSEARCH_PORT=9200
 OPENSEARCH_HEALTHCHECK_TIMEOUT=100
 
 ## Set custom heap size to avoid memory errors
-ES_JAVA_OPTS="-Xms1g -Xmx1g"
+OPENSEARCH_JAVA_OPTS="-Xms1g -Xmx1g"
 
 # Prevent security patch conflicts with core M2 code
 DISABLE_SECURITY_PLUGIN=true


### PR DESCRIPTION
Let [what-the-diff](https://github.com/apps/what-the-diff) bot tell us.

We can check the heap max size of the search engine (opensearch) by this command:

`bin/cli curl -sS  "opensearch:9200/_cat/nodes?h=heap*&v"`