### PR TITLE
Use short link for repo's path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,18 @@
 View Dockerfiles for the latest tags:
 
 - [markoshust/magento-nginx (Docker Hub)](https://hub.docker.com/r/markoshust/magento-nginx/)
-  - [`1.18`, `1.18-8`](https://github.com/markshust/docker-magento/tree/master/images/nginx/1.18)
+  - [`1.18`, `1.18-8`](images/nginx/1.18)
 - [markoshust/magento-php (Docker Hub)](https://hub.docker.com/r/markoshust/magento-php/)
-  - [`8.1-fpm`, `8.1-fpm-1`](https://github.com/markshust/docker-magento/tree/master/images/php/8.1)
+  - [`8.1-fpm`, `8.1-fpm-1`](images/php/8.1)
 - [markoshust/magento-opensearch (Docker Hub)](https://hub.docker.com/r/markoshust/magento-opensearch/)
-    - [`1.2`, `1.2-0`](https://github.com/markshust/docker-magento/tree/master/images/opensearch/1.2)
+    - [`1.2`, `1.2-0`](images/opensearch/1.2)
 - [markoshust/magento-elasticsearch (Docker Hub)](https://hub.docker.com/r/markoshust/magento-elasticsearch/)
-  - [`7.16`, `7.16-0`](https://github.com/markshust/docker-magento/tree/master/images/elasticsearch/7.16)
-  - [`7.17`, `7.17-0`](https://github.com/markshust/docker-magento/tree/master/images/elasticsearch/7.17)
+  - [`7.16`, `7.16-0`](images/elasticsearch/7.16)
+  - [`7.17`, `7.17-0`](images/elasticsearch/7.17)
 - [markoshust/magento-rabbitmq (Docker Hub)](https://hub.docker.com/r/markoshust/magento-rabbitmq/)
-  - [`3.9`, `3.9-0`](https://github.com/markshust/docker-magento/tree/master/images/rabbitmq/3.9)
+  - [`3.9`, `3.9-0`](images/rabbitmq/3.9)
 - [markoshust/ssh (Docker Hub)](https://hub.docker.com/r/markoshust/magento-ssh/)
-  - [`latest`](https://github.com/markshust/docker-magento/tree/master/images/ssh)
+  - [`latest`](images/ssh)
 
 ## Free Course
 
@@ -501,7 +501,7 @@ Copy `compose.dev-linux.yaml` to `compose.dev.yaml` before installing Magento to
 
 The `host.docker.internal` hostname is used on Docker for Mac/Windows to reference the Docker daemon. On Linux, this hostname does not exist.
 
-This hostname is [hard-coded in the php.ini file](https://github.com/markshust/docker-magento/blob/master/images/php/8.1/conf/php.ini#L8). To make this hostname resolve, add `"host.docker.internal:172.17.0.1"` to the `app.extra_hosts` parameter of `compose.yaml`, replacing `172.17.0.1` with the result of:
+This hostname is [hard-coded in the php.ini file](images/php/8.1/conf/php.ini#L8). To make this hostname resolve, add `"host.docker.internal:172.17.0.1"` to the `app.extra_hosts` parameter of `compose.yaml`, replacing `172.17.0.1` with the result of:
 
 ```
 docker run --rm alpine ip route | awk 'NR==1 {print $3}'


### PR DESCRIPTION
Based on [Autolinked references and URLs  - Github](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls)

I skipped the [CHANGELOG.md](CHANGELOG.md), it's too many links, lol.

Let [what-the-diff](https://github.com/apps/what-the-diff) bot tell us more.