### PR TITLE
OpenSearch -> Elasticsearch Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,12 @@ bin/restart
 open https://magento.test
 ```
 
+### Elasticsearch vs OpenSearch
+OpenSearch is set as the default search engine when setting up this project. Follow the instructions below if you want to use Elasticsearch instead:
+1. Comment out or remove the `opensearch` container in both the [`compose.yaml`](https://github.com/markshust/docker-magento/blob/master/compose/compose.yaml#L55-L66) and [`compose.healthcheck.yaml`](https://github.com/markshust/docker-magento/blob/master/compose/compose.healthcheck.yaml#L38-L43) files
+2. Uncomment the `elasticsearch` container in both the [`compose.yaml`](https://github.com/markshust/docker-magento/blob/master/compose/compose.yaml#L70-L81) and [`compose.healthcheck.yaml`](https://github.com/markshust/docker-magento/blob/master/compose/compose.healthcheck.yaml#L45-L50) files
+3. Update the `bin/setup` command to use the [`$ES_HOST` variable as the value for the `--elasticsearch-host` argument passed to `setup:install`](https://github.com/markshust/docker-magento/blob/master/compose/bin/setup#L65)
+
 ## Updates
 
 To update your project to the latest version of `docker-magento`, run:

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -67,6 +67,9 @@ services:
 
   ## If you wish to use Elasticsearch, comment out opensearch image above and
   ## uncomment this block. Do the same in the composer.healthcheck.yaml file.
+  # Additionally, if you are performing the manual setup, you will need to
+  # update the bin/setup command to use the $ES_HOST variable as the value for
+  # the --elasticsearch-host argument passed to bin/magento setup:install.
   #elasticsearch:
   #  image: markoshust/magento-elasticsearch:7.17-0
   #  ports:


### PR DESCRIPTION
# Description
Some of the changes required to successfully switch from using OpenSearch to Elasticsearch are undocumented. This has caused people issues so let's document the steps required to make the switch as easy as possible.

Ideally the change to the `bin/setup` script would not be required - instead detecting which search service you are using and using the appropriate `--elasticsearch-host` value during `setup:install`. Unfortunately I don't have the time to look into this at the moment so this might be the next best thing 🤷‍♂️ 

# Related Issues
#829 