### PR TITLE
Stop Containers Before Removing

### DIFF
--- a/compose/bin/removeall
+++ b/compose/bin/removeall
@@ -1,3 +1,4 @@
 #!/bin/bash
+bin/stopall
 bin/remove
 bin/removevolumes


### PR DESCRIPTION
# Description
Remove the need for manually stopping all containers before removing them when running `bin/removeall`.

Another opinionated change so input and discussion is welcome 🙂 
