### PR TITLE
Update bin/removeall Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ It is recommended to keep your root docker config files in one repository, and y
 - `bin/pwa-studio`: (BETA) Start the PWA Studio server. Note that Chrome will throw SSL cert errors and not allow you to view the site, but Firefox will.
 - `bin/redis`: Run a command from the redis container. Ex. `bin/redis redis-cli monitor`
 - `bin/remove`: Remove all containers.
-- `bin/removeall`: Remove all containers, networks, volumes, and images.
+- `bin/removeall`: Remove all containers, networks, volumes, and images, calling `bin/stopall` before doing so.
 - `bin/removevolumes`: Remove all volumes.
 - `bin/restart`: Stop and then start all containers.
 - `bin/root`: Run any CLI command as root without going into the bash prompt. Ex `bin/root apt-get install nano`


### PR DESCRIPTION
# Description
Updates `bin/removeall` command description to inform people that it also calls `bin/stopall`. This should have been done as part of #837 .