### PR TITLE
Enable xdebug to listen to Magento CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ It is recommended to keep your root docker config files in one repository, and y
 - `bin/devconsole`: Alias for `bin/n98-magerun2 dev:console`
 - `bin/docker-compose`: Support V1 (`docker-compose`) and V2 (`docker compose`) docker compose command, and use custom configuration files, such as `compose.yml` and `compose.dev.yml`
 - `bin/download`: Download specific Magento version from Composer to the container, with optional arguments of the version (2.4.5-p1 [default]) and type ("community" [default], "enterprise", or "mageos"). Ex. `bin/download 2.4.5-p1 enterprise`
+- `bin/debug-cli`: Enable xdebug for Magento Console Command. Second argument is optional, default is PHPSTORM Ex. `bin/debug-cli enable [PHPSTORM]`
 - `bin/fixowns`: This will fix filesystem ownerships within the container.
 - `bin/fixperms`: This will fix filesystem permissions within the container.
 - `bin/grunt`: Run the grunt binary. Ex. `bin/grunt exec`

--- a/compose/bin/debug-cli
+++ b/compose/bin/debug-cli
@@ -1,0 +1,61 @@
+#!/bin/bash
+S=$(bin/clinotty cat /usr/local/etc/php/php.ini | grep -iGc 'xdebug.mode = off');
+
+if [[ $S == 1 ]]; then
+  echo "Enable xdebug first"
+  exit 1
+fi
+
+R=$(cat ./env/phpfpm.env | grep -c 'XDEBUG_CONFIG=idekey')
+
+if [[ -z "$2" ]]
+  then
+    platform="PHPSTORM"
+  else
+    platform=$2
+fi
+
+local_debug_status(){
+  if [[ $R == 1 ]]; then
+    echo "Cli debug enabled"
+  else
+    echo "Cli debug disabled"
+  fi
+}
+
+local_debug_toggle() {
+    if [[ $R == 1 ]]; then
+      local_debug_disable
+    else
+      local_debug_enable
+    fi
+}
+
+local_debug_enable() {
+  if [[ $R == 1 ]]; then
+    echo "Already enabled"
+    exit 0
+  fi
+  echo "XDEBUG_CONFIG=idekey=$platform" >> ./env/phpfpm.env
+  echo "Cli debug enabled"
+}
+
+local_debug_disable() {
+  sed -i '' '/XDEBUG_CONFIG=idekey/d' ./env/phpfpm.env
+  echo "Cli debug disabled"
+}
+
+firstArgLetter="$(echo "$1" | head -c 1)"
+
+
+if [[ $firstArgLetter == "d" ]]; then
+  local_debug_disable
+elif [[ $firstArgLetter == "e" ]]; then
+  local_debug_enable
+elif [[ $firstArgLetter == "t" ]]; then
+  local_debug_toggle
+elif [[ $firstArgLetter == "s" ]]; then
+  local_debug_status
+else
+    printf "Please specify either 'disable', 'enable', 'status' or 'toggle' as mandatory argument.\nSpecify as an optional second argument the platform. Default is PHPSTORM\nEx: bin/debug-cli enable [PHPSTORM]\n"
+fi


### PR DESCRIPTION
Hi Mark, i added this script because often i need to debug some console commands and i used to edit the env/phpfpm.env   and roll it back manually.

Let me know if you're interested on that.