### PR TITLE
Simplify RAM check

### DIFF
--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -o errexit
 
-MEM=$(docker info | grep "Total Memory" | cut -d':' -f2 | xargs | sed s/GiB//)
-# Docker reports RAM 0.2 less than what it is actually set to
-(( $(echo "$MEM < 5.7" | bc -l) )) && echo "There must be at least 6GB of RAM allocated to Docker to continue." && exit
+MEM_BYTES=$(docker info -f '{{.MemTotal}}')
+MEM_MB=$(( MEM_BYTES / 1000000 ))
+(( MEM_MB >= 6000 )) || {
+  echo 'There must be at least 6GB of RAM allocated to Docker to continue.' >&2
+  exit 1
+}
 
 # shellcheck source=../env/db.env
 source env/db.env

--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -3,10 +3,8 @@ set -o errexit
 
 MEM_BYTES=$(docker info -f '{{.MemTotal}}')
 MEM_MB=$(( MEM_BYTES / 1000000 ))
-(( MEM_MB >= 6000 )) || {
-  echo 'There must be at least 6GB of RAM allocated to Docker to continue.' >&2
-  exit 1
-}
+# When Docker Desktop is set to 6GB in the GUI, it is reported as 6227 MB
+(( MEM_MB < 6227 )) && echo "There must be at least 6GB of RAM allocated to Docker in order to continue." && exit
 
 # shellcheck source=../env/db.env
 source env/db.env


### PR DESCRIPTION
Use `docker info -f` to get the number of bytes. This results in fewer dependencies on external programs, and better usage of Bash shell math.

Removes comment stemming from confusion about GiB vs GB. :-)