### PR TITLE
Add support for multi-storefront Magento

### DIFF
--- a/compose/bin/docker-compose
+++ b/compose/bin/docker-compose
@@ -6,8 +6,24 @@ else
   DOCKER_COMPOSE="docker-compose"
 fi
 
-if [ "$1" == "--no-dev" ]; then
-  ${DOCKER_COMPOSE} -f compose.yaml -f compose.healthcheck.yaml "${@:2}"
-else
-  ${DOCKER_COMPOSE} -f compose.yaml -f compose.healthcheck.yaml -f compose.dev.yaml "$@"
+DOCKER_COMPOSE_YAMLS=(
+  compose.yaml
+  compose.healthcheck.yaml
+)
+
+if [[ -f src/php.ini && -f src/magento-vars.php ]]; then
+  DOCKER_COMPOSE_YAMLS+=(compose.multi-storefront.yaml)
 fi
+if [[ $1 = '--no-dev' ]]; then
+  shift 1
+else
+  DOCKER_COMPOSE_YAMLS+=(compose.dev.yaml)
+fi
+
+DOCKER_COMPOSE_ARGS=()
+for YAML in "${DOCKER_COMPOSE_YAMLS[@]}"; do
+  DOCKER_COMPOSE_ARGS+=(-f "$YAML")
+done
+${DOCKER_COMPOSE} \
+  "${DOCKER_COMPOSE_ARGS[@]}" \
+  "$@"

--- a/compose/compose.multi-storefront.yaml
+++ b/compose/compose.multi-storefront.yaml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  app:
+    volumes: &appvolumes
+      # Magento Cloud-like path support
+      - ./src:/app:cached
+      # Multi-storefront support depends on "auto_prepend_file = /app/magento-vars.php" being in src/php.ini
+      - ./src/php.ini:/usr/local/etc/php/conf.d/local-php.ini:cached
+
+  phpfpm:
+    volumes: *appvolumes


### PR DESCRIPTION
**I really want to know if the method described under `How multi-storefront switching works` is the standard way of switching between storefronts, or if it's just a technique peculiar to my workplace.**

This *may* be going too far towards how one hosting solution (Adobe's Magento Cloud service) sets things up; other hosting solutions are available.

## My change

(Aside from a slight refactor to make it easier) this change adds an additional YAML file, `compose.multi-storefront.yaml`, that adds 2 additional volumes to `app` and `phpfpm`:
- `src` -> `/app` - this mimics the directory layout when deployed to Magento Cloud.
- `src/php.ini` -> `/usr/local/etc/php/conf.d/local-php.ini` - mapped so that PHP will load it.

It *only* uses `compose.multi-storefront.yaml` if both `src/php.ini` and `src/magento-vars.php` exist.

## How multi-storefront switching works

Multi-storefront switching is performed by modifying the `$_SERVER['MAGE_RUN_CODE']` and `$_SERVER['MAGE_RUN_TYPE']` values inside of `$_SERVER`. It's done in a special file called `magento-vars.php`. Here's an example:

```php
<?php
/**
 * Copyright © Magento, Inc. All rights reserved.
 * See COPYING.txt for license details.
 */

/**
 * Enable, adjust and copy this code for each store you run
 *
 * Store #0, default one
 *
 * if (isHttpHost("example.com")) {
 *    $_SERVER["MAGE_RUN_CODE"] = "default";
 *    $_SERVER["MAGE_RUN_TYPE"] = "store";
 * }
 *
 * @param string $host
 * @return bool
 */
function isHttpHost(string $host)
{
    if (!isset($_SERVER['HTTP_HOST'])) {
        return false;
    }
    return $_SERVER['HTTP_HOST'] === $host;
}
/**
 * Enable, adjust and copy this code for each store you run
 *
 * Store #0, default one
 */
if (
    isHttpHost("www.defaultstore.example.com")
    || isHttpHost("defaultstore.example.com")
    || isHttpHost("defaultstore.example.dev")
) {
    $_SERVER["MAGE_RUN_CODE"] = "default";
    $_SERVER["MAGE_RUN_TYPE"] = "store";
}
if (
    isHttpHost("www.store1.example.com")
    || isHttpHost("store1.example.com")
    || isHttpHost("store1.example.dev")
) {
    $_SERVER["MAGE_RUN_CODE"] = "store1_store_view";
    $_SERVER["MAGE_RUN_TYPE"] = "store";
}
```

This file is included in every request via `src/php.ini`:
```ini
;
; Multi store support
;
auto_prepend_file = /app/magento-vars.php
```

Using our same example domains, getting this setup for local development depends on modifications to `/etc/hosts` to make both `defaultstore.example.dev` and `store1.example.dev` work in the browser:
```hosts
127.0.0.1 ::1 defaultstore.example.dev
127.0.0.1 ::1 store1.example.dev
```

Running `bin/setup-ssl defaultstore.example.dev store1.example.dev` is not a bad idea either.