### PR TITLE
Setup script is divided to 2 parts

### DIFF
--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -6,17 +6,6 @@ MEM_MB=$(( MEM_BYTES / 1000000 ))
 # When Docker Desktop is set to 6GB in the GUI, it is reported as 6227 MB
 (( MEM_MB < 6227 )) && echo "There must be at least 6GB of RAM allocated to Docker in order to continue." && exit
 
-# shellcheck source=../env/db.env
-source env/db.env
-# shellcheck source=../env/elasticsearch.env
-source env/elasticsearch.env
-# shellcheck source=../env/opensearch.env
-source env/opensearch.env
-# shellcheck source=../env/magento.env
-source env/magento.env
-# shellcheck source=../env/rabbitmq.env
-source env/rabbitmq.env
-
 DOMAIN=${1:-magento.test}
 
 bin/stop
@@ -32,41 +21,8 @@ bin/clinotty composer config --no-plugins allow-plugins.magento/magento-composer
 bin/clinotty composer config --no-plugins allow-plugins.magento/inventory-composer-installer true
 bin/clinotty composer config --no-plugins allow-plugins.laminas/laminas-dependency-plugin true
 
-bin/clinotty bin/magento setup:install \
-  --db-host="$MYSQL_HOST" \
-  --db-name="$MYSQL_DATABASE" \
-  --db-user="$MYSQL_USER" \
-  --db-password="$MYSQL_PASSWORD" \
-  --base-url=https://"$DOMAIN"/ \
-  --base-url-secure=https://"$DOMAIN"/ \
-  --backend-frontname="$MAGENTO_ADMIN_FRONTNAME" \
-  --admin-firstname="$MAGENTO_ADMIN_FIRST_NAME" \
-  --admin-lastname="$MAGENTO_ADMIN_LAST_NAME" \
-  --admin-email="$MAGENTO_ADMIN_EMAIL" \
-  --admin-user="$MAGENTO_ADMIN_USER" \
-  --admin-password="$MAGENTO_ADMIN_PASSWORD" \
-  --language="$MAGENTO_LOCALE" \
-  --currency="$MAGENTO_CURRENCY" \
-  --timezone="$MAGENTO_TIMEZONE" \
-  --amqp-host="$RABBITMQ_HOST" \
-  --amqp-port="$RABBITMQ_PORT" \
-  --amqp-user="$RABBITMQ_DEFAULT_USER" \
-  --amqp-password="$RABBITMQ_DEFAULT_PASS" \
-  --amqp-virtualhost="$RABBITMQ_DEFAULT_VHOST" \
-  --cache-backend=redis \
-  --cache-backend-redis-server=redis \
-  --cache-backend-redis-db=0 \
-  --page-cache=redis \
-  --page-cache-redis-server=redis \
-  --page-cache-redis-db=1 \
-  --session-save=redis \
-  --session-save-redis-host=redis \
-  --session-save-redis-log-level=4 \
-  --session-save-redis-db=2 \
-  --elasticsearch-host=$OPENSEARCH_HOST \
-  --elasticsearch-port=$OPENSEARCH_PORT \
-  --use-rewrites=1 \
-  --no-interaction
+echo "Running, Magento setup:install..."
+bin/setup-install "${DOMAIN}"
 
 echo "Copying files from container to host after install..."
 bin/copyfromcontainer --all

--- a/compose/bin/setup-install
+++ b/compose/bin/setup-install
@@ -1,0 +1,49 @@
+
+DOMAIN=${1:-magento.test}
+
+# shellcheck source=../env/db.env
+source env/db.env
+# shellcheck source=../env/elasticsearch.env
+source env/elasticsearch.env
+# shellcheck source=../env/opensearch.env
+source env/opensearch.env
+# shellcheck source=../env/magento.env
+source env/magento.env
+# shellcheck source=../env/rabbitmq.env
+source env/rabbitmq.env
+
+bin/clinotty bin/magento setup:install \
+  --db-host="$MYSQL_HOST" \
+  --db-name="$MYSQL_DATABASE" \
+  --db-user="$MYSQL_USER" \
+  --db-password="$MYSQL_PASSWORD" \
+  --base-url=https://"$DOMAIN"/ \
+  --base-url-secure=https://"$DOMAIN"/ \
+  --backend-frontname="$MAGENTO_ADMIN_FRONTNAME" \
+  --admin-firstname="$MAGENTO_ADMIN_FIRST_NAME" \
+  --admin-lastname="$MAGENTO_ADMIN_LAST_NAME" \
+  --admin-email="$MAGENTO_ADMIN_EMAIL" \
+  --admin-user="$MAGENTO_ADMIN_USER" \
+  --admin-password="$MAGENTO_ADMIN_PASSWORD" \
+  --language="$MAGENTO_LOCALE" \
+  --currency="$MAGENTO_CURRENCY" \
+  --timezone="$MAGENTO_TIMEZONE" \
+  --amqp-host="$RABBITMQ_HOST" \
+  --amqp-port="$RABBITMQ_PORT" \
+  --amqp-user="$RABBITMQ_DEFAULT_USER" \
+  --amqp-password="$RABBITMQ_DEFAULT_PASS" \
+  --amqp-virtualhost="$RABBITMQ_DEFAULT_VHOST" \
+  --cache-backend=redis \
+  --cache-backend-redis-server=redis \
+  --cache-backend-redis-db=0 \
+  --page-cache=redis \
+  --page-cache-redis-server=redis \
+  --page-cache-redis-db=1 \
+  --session-save=redis \
+  --session-save-redis-host=redis \
+  --session-save-redis-log-level=4 \
+  --session-save-redis-db=2 \
+  --elasticsearch-host=$OPENSEARCH_HOST \
+  --elasticsearch-port=$OPENSEARCH_PORT \
+  --use-rewrites=1 \
+  --no-interaction


### PR DESCRIPTION
Sometimes we just need to run bin/magento setup:install script, so maybe it can be a better approach to divide the setup script to can use the setup-install command alone.