### PR TITLE
Modify RabbitMQ credentials in test templates to comply with rabbitmq.env

### DIFF
--- a/compose/template/dev/tests/integration/etc/install-config-mysql.php.2.3.dist
+++ b/compose/template/dev/tests/integration/etc/install-config-mysql.php.2.3.dist
@@ -17,6 +17,6 @@ return [
     'admin-lastname' => \Magento\TestFramework\Bootstrap::ADMIN_LASTNAME,
     'amqp-host' => 'rabbitmq',
     'amqp-port' => '5672',
-    'amqp-user' => 'guest',
-    'amqp-password' => 'guest',
+    'amqp-user' => 'magento',
+    'amqp-password' => 'magento',
 ];

--- a/compose/template/dev/tests/integration/etc/install-config-mysql.php.2.4.dist
+++ b/compose/template/dev/tests/integration/etc/install-config-mysql.php.2.4.dist
@@ -19,6 +19,6 @@ return [
     'admin-lastname' => \Magento\TestFramework\Bootstrap::ADMIN_LASTNAME,
     'amqp-host' => 'rabbitmq',
     'amqp-port' => '5672',
-    'amqp-user' => 'guest',
-    'amqp-password' => 'guest',
+    'amqp-user' => 'magento',
+    'amqp-password' => 'magento',
 ];


### PR DESCRIPTION
When running the integration tests, it fails to connect to RabbitMQ because the pre-made integration tests configuration templates contain different RabbitMQ login credentials than are in rabbitmq.env.

This pull request modifies the templates to contain the same values as the default rabbitmq.env values

