### PR TITLE
Tweak version detection in setup-integration-tests script

### DIFF
--- a/compose/bin/setup-integration-tests
+++ b/compose/bin/setup-integration-tests
@@ -13,7 +13,7 @@ bin/clinotty mysql -h"${MYSQL_INTEGRATION_HOST}" -uroot -p"${MYSQL_ROOT_PASSWORD
     -e "GRANT ALL PRIVILEGES ON ${MYSQL_INTEGRATION_DATABASE}.* TO '${MYSQL_INTEGRATION_USER}'@'%';FLUSH PRIVILEGES;"
 
 if [[ ! -f "src/${MYSQL_INTEGRATION_CONFIG}" ]]; then
-  MAGENTO_VERSION=$(bin/magento --version --no-ansi | cut -d" " -f 3)
+  MAGENTO_VERSION=$(bin/magento --version --no-ansi | grep "Magento" | cut -d" " -f 3)
   IFS=. read -r -a MAGENTO_VERSION_SEGMENTS <<< "${MAGENTO_VERSION}"
   MAGENTO_MAJOR="${MAGENTO_VERSION_SEGMENTS[0]}.${MAGENTO_VERSION_SEGMENTS[1]}"
   cp template/"${MYSQL_INTEGRATION_CONFIG}"."${MAGENTO_MAJOR}".dist src/${MYSQL_INTEGRATION_CONFIG}


### PR DESCRIPTION
I've made some changes to the `setup-integration-test` script that addresses an issue where it was not possible to use the script when a specific configuration of Xdebug was in place. 

With this pull request, I've tweaked the version detection to evaluate only rows with the Magento string. The tweak should help to resolve the issue and make the script more reliable overall.

(this is an example output of `bin/magento --version --no-ansi` when xdebug is enabled on each request and disabled PHPStorm's Listening for Debug Connection)
![image](https://user-images.githubusercontent.com/7402947/230360618-01464b6e-1f3c-49fa-838a-8b0587580893.png)

Thank you @markshust for your hard work in maintaining this package!

