### PR TITLE
Create bin/deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ It is recommended to keep your root docker config files in one repository, and y
 - `bin/docker-compose`: Support V1 (`docker-compose`) and V2 (`docker compose`) docker compose command, and use custom configuration files, such as `compose.yml` and `compose.dev.yml`
 - `bin/download`: Download specific Magento version from Composer to the container, with optional arguments of the version (2.4.6 [default]) and type ("community" [default], "enterprise", or "mageos"). Ex. `bin/download 2.4.6 enterprise`
 - `bin/debug-cli`: Enable Xdebug for bin/magento, with an optional argument of the IDE key. Defaults to PHPSTORM Ex. `bin/debug-cli enable PHPSTORM`
+- `bin/deploy`: Runs the standard Magento deployment process commands. Pass extra locales besides `en_US` via an optional argument. Ex. `bin/deploy nl_NL`
 - `bin/fixowns`: This will fix filesystem ownerships within the container.
 - `bin/fixperms`: This will fix filesystem permissions within the container.
 - `bin/grunt`: Run the grunt binary. Ex. `bin/grunt exec`

--- a/compose/bin/deploy
+++ b/compose/bin/deploy
@@ -1,19 +1,10 @@
 #!/usr/bin/env bash
-bin/composer install;
-bin/magento maintenance:enable;
-bin/cli rm -rf generated/code var/view_preprocessed;
-
-echo "$ bin/magento cache:flush";
-bin/magento cache:flush;
-
-echo "$ bin/magento setup:upgrade";
-bin/magento setup:upgrade;
-
-echo "$ bin/ magento setup:di:compile";
-bin/magento setup:di:compile;
-
-echo "$ bin/magento setup:static-content:deploy nl_NL en_US -f";
-bin/magento setup:static-content:deploy nl_NL en_US -f;
-
-bin/magento maintenance:disable;
-bin/magento cache:flush;
+bin/composer install
+bin/magento maintenance:enable
+bin/cli rm -rf generated/code var/view_preprocessed
+bin/magento cache:flush
+bin/magento setup:upgrade
+bin/magento setup:di:compile
+bin/magento setup:static-content:deploy en_US "$@" -f
+bin/magento maintenance:disable
+bin/magento cache:flush

--- a/compose/bin/deploy
+++ b/compose/bin/deploy
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+bin/composer install;
+bin/magento maintenance:enable;
+bin/cli rm -rf generated/code var/view_preprocessed;
+
+echo "$ bin/magento cache:flush";
+bin/magento cache:flush;
+
+echo "$ bin/magento setup:upgrade";
+bin/magento setup:upgrade;
+
+echo "$ bin/ magento setup:di:compile";
+bin/magento setup:di:compile;
+
+echo "$ bin/magento setup:static-content:deploy nl_NL en_US -f";
+bin/magento setup:static-content:deploy nl_NL en_US -f;
+
+bin/magento maintenance:disable;
+bin/magento cache:flush;


### PR DESCRIPTION
I've extended your magnificent setup with this bin command to deploy the changes in my setup. 

Might it be useful to others in this project too?


```
#!/usr/bin/env bash
bin/composer install;
bin/magento maintenance:enable;
bin/cli rm -rf generated/code var/view_preprocessed;

echo "$ bin/magento cache:flush";
bin/magento cache:flush;

echo "$ bin/magento setup:upgrade";
bin/magento setup:upgrade;

echo "$ bin/ magento setup:di:compile";
bin/magento setup:di:compile;

echo "$ bin/magento setup:static-content:deploy nl_NL en_US -f";
bin/magento setup:static-content:deploy nl_NL en_US -f;

bin/magento maintenance:disable;
bin/magento cache:flush;
```