### PR TITLE
bin/setup-grunt without changing compose.dev.yaml

### DIFF
--- a/compose/bin/setup-grunt
+++ b/compose/bin/setup-grunt
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 echo "Confirming n98-magerun2 is installed..."
 bin/n98-magerun2 > /dev/null 2>&1
 
@@ -36,10 +37,15 @@ else
     bin/node -e "$GEN_THEME_JS"
 fi
 
-# Create files from sample files if they do not yet exist
-test -f src/package.json || cp src/package.json.sample src/package.json
-test -f src/Gruntfile.js || cp src/Gruntfile.js.sample src/Gruntfile.js
-test -f src/grunt-config.json || cp src/grunt-config.json.sample src/grunt-config.json
+# Create sample files from magento base folder if they do not yet exist
+if [ ! -f "src/package.json" ] || [ ! -f "src/Gruntfile.js" ] || [ ! -f "src/grunt-config.json" ]; then
+    M2_BASE="vendor/magento/magento2-base"
+    mkdir -p src/$M2_BASE
+    bin/copyfromcontainer $M2_BASE
+    cp src/$M2_BASE/package.json.sample src/package.json
+    cp src/$M2_BASE/Gruntfile.js.sample src/Gruntfile.js
+    cp src/$M2_BASE/grunt-config.json.sample src/grunt-config.json
+fi
 
 # Disable grunt-contrib-jasmine on ARM processors (incompatible)
 if [ "$(uname -m)" == "arm64" ]; then
@@ -47,14 +53,10 @@ if [ "$(uname -m)" == "arm64" ]; then
       && mv package.json src/package.json
 fi
 
-# Enable these custom files on compose.dev.yaml so custom updates are persisted
-sed -e 's/grunt-config.json.sample/grunt-config.json/' compose.dev.yaml > compose.dev.yaml.updated \
- && mv compose.dev.yaml.updated compose.dev.yaml
-sed -e 's/Gruntfile.js.sample/Gruntfile.js/' compose.dev.yaml > compose.dev.yaml.updated \
- && mv compose.dev.yaml.updated compose.dev.yaml
-sed -e 's/package.json.sample/package.json/' compose.dev.yaml > compose.dev.yaml.updated \
- && mv compose.dev.yaml.updated compose.dev.yaml
-bin/restart app phpfpm
+echo "Moving package.json, Gruntfile.js, and grunt-config.json into the container"
+bin/copytocontainer package.json > /dev/null
+bin/copytocontainer Gruntfile.js > /dev/null
+bin/copytocontainer grunt-config.json > /dev/null
 
 bin/npm install ajv@^5.0.0 --save
 bin/npm install

--- a/compose/compose.dev.yaml
+++ b/compose/compose.dev.yaml
@@ -9,11 +9,8 @@ services:
       - ./src/app/etc:/var/www/html/app/etc:cached
       - ./src/composer.json:/var/www/html/composer.json:cached
       - ./src/composer.lock:/var/www/html/composer.lock:cached
-      - ./src/grunt-config.json.sample:/var/www/html/grunt-config.json:cached
-      - ./src/Gruntfile.js.sample:/var/www/html/Gruntfile.js:cached
       - ./src/dev/tools/grunt/configs:/var/www/html/dev/tools/grunt/configs:cached
       - ./src/nginx.conf.sample:/var/www/html/nginx.conf:cached
-      - ./src/package.json.sample:/var/www/html/package.json:cached
       #- ./src/auth.json:/var/www/html/auth.json:cached
       #- ./src/m2-hotfixes:/var/www/html/m2-hotfixes:cached
       #- ./src/patches:/var/www/html/patches:cached


### PR DESCRIPTION
- No need to change the `compose.dev.yaml` to keep it simple and integrity. (`bin/update` will overwrite `compose.dev.yaml`)
- Remove `grunt-config.json`, `Gruntfile.js`, and `package.json` in `compose.dev.yaml`
- No need to`bin/restart app phpfpm`
- Copy sample files from `vendor/magento/magento2-base`, no need to worry about whether `src` folder has files.
- To customize the settings ( `grunt-config.json`, `Gruntfile.js`, and `package.json` ) , you can edit the files in the `src` folder and then run the `bin/setup-grunt` to copy the settings into the container.