### PR TITLE
Update copyfromcontainer to create src folder

### DIFF
--- a/compose/bin/copyfromcontainer
+++ b/compose/bin/copyfromcontainer
@@ -2,6 +2,9 @@
 [ -z "$1" ] && echo "Please specify a directory or file to copy from container (ex. vendor, --all)" && exit
 
 REAL_SRC=$(cd -P "src" && pwd)
+if [ ! -d "$REAL_SRC" ]; then
+  mkdir -p "$REAL_SRC"
+fi
 if [ "$1" == "--all" ]; then
   docker cp "$(bin/docker-compose ps -q phpfpm|awk '{print $1}')":/var/www/html/./ "$REAL_SRC/"
   echo "Completed copying all files from container to host"


### PR DESCRIPTION
It creates the src folder when copying all the code from the repo first the first time, by the src doesn't exist. 

An example is when the dev follows the README part saying to run bin/cli git clone .... to start the project.