### PR TITLE
Update setup-install to cleanup

### DIFF
--- a/compose/bin/setup-install
+++ b/compose/bin/setup-install
@@ -53,4 +53,5 @@ bin/clinotty bin/magento setup:install \
   --opensearch-port="$OPENSEARCH_PORT" \
   --search-engine=opensearch \
   --use-rewrites=1 \
+  --cleanup-database \
   --no-interaction


### PR DESCRIPTION
The usage of `--cleanup-database` helps to finish the installation in most of cases, avoiding small fixable issues during clean installations and installations with pre-created databases as well.