### PR TITLE
Add Optional Support for Cloudflare Tunnels

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,19 @@ Next, open up the `bin/start` helper script and uncomment the line:
 
 Finally, restart the containers with `bin/restart`. After doing so, everything is now configured and you can use a browser extension to profile your Magento store with Blackfire.
 
+### Cloudflare Tunnel
+
+These docker images have built-in support for Cloudflare Tunnel. It can be useful for testing implementations that require some third-party integrations involving allow-listing domains. Since your local app cannot be allow-listed by other services - you can use Cloudflare Tunnel to get public hostname that can be allow-listed on the other service.
+
+To use it, first create a tunnel in Cloudflare Zero Trust and add the token to `env/cloudflare.env`.
+
+Next, uncomment Cloudlfare Tunnel section in main `compose.yaml`.
+
+Finally, restart the containers with `bin/restart`.
+In Cloudflare Tunnel configuration - configure service URL to use type `HTTPS` and URL `{name of app container}:{HTTPS port of app container}`, for example - `demo-app-1:8443`. Enable `No TLS Verify` option since our local certificates are self-signed. You should now be able to access your app via public hostname, defined in Cloudflare Tunnel.
+
+NOTE: do not leave instances with Cloudflare Tunnel enabled running long-term, as your instance is publicly available to the world. You should ideally turn off tunnel container once testing is finished. 
+
 ### MFTF
 
 To work with MFTF you will need to first enable the `selenium` image in the `compose.dev.yaml` file. Then, you will need to run the following.

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -98,7 +98,14 @@ services:
     image: sj26/mailcatcher
     ports:
       - "1080:1080"
-
+  
+  ## Cloudflare tunnel support, uncomment to enable
+  #tunnel:
+  #  container_name: cloudflared-tunnel
+  #  image: cloudflare/cloudflared:latest
+  #  command: tunnel run
+  #  env_file: env/cloudflare.env
+  
   ## Blackfire support, uncomment to enable
   #blackfire:
   #  image: blackfire/blackfire:2

--- a/compose/env/cloudflare.env
+++ b/compose/env/cloudflare.env
@@ -1,0 +1,1 @@
+TUNNEL_TOKEN=


### PR DESCRIPTION
This MR adds support for Cloudflare Tunnels (https://www.cloudflare.com/products/tunnel/).
This is helpful when you need your instance to have public domain, so you can allowlist it with 3-p services that don't allow connections from localhost.

**Added:**
- Main config update (commented Cloudflare Tunnel section)
- Env file for Cloudflare to include your tunnel's token
- Update to Readme to cover setup part

**NOTE:** Cloudflare Tunnel makes app visible to the world, so use it carefully to not leave Magento instance always available publicly.