### PR TITLE
rework docker compose script to allow future extensibility

### DIFF
--- a/compose/bin/docker-compose
+++ b/compose/bin/docker-compose
@@ -15,8 +15,9 @@ else
   COMPOSE_FILES+=("compose.dev.yaml")
 fi
 
+# We create an array including files prefixed with -f here
+# to ensure paths with spaces aren't split when passed as parameters
 COMPOSE_FILES_PREFIXED=()
-
 for file in "${COMPOSE_FILES[@]}"; do
   COMPOSE_FILES_PREFIXED+=("-f" "$file")
 done

--- a/compose/bin/docker-compose
+++ b/compose/bin/docker-compose
@@ -8,15 +8,18 @@ fi
 
 COMPOSE_FILES=("compose.yaml" "compose.healthcheck.yaml")
 
+# If --no-dev is passed to this script, we won't load the compose.dev.yaml file,
+# but this argument should be removed so it isn't passed to docker compose.
 if [ "$1" == "--no-dev" ]; then
-  # ensure --no-dev parameter isn't passed to docker compose
+  # Remove the "--no-dev" argument so it isn't passed to docker compose
   shift 1
 else
+  # The "--no-dev" argument wasn't passed in, so let's load the dev config.
   COMPOSE_FILES+=("compose.dev.yaml")
 fi
 
-# We create an array including files prefixed with -f here
-# to ensure paths with spaces aren't split when passed as parameters
+# Loop over the list of compose files, and prefix them with -f.
+# This ensures paths with spaces aren't split when passed as parameters.
 COMPOSE_FILES_PREFIXED=()
 for file in "${COMPOSE_FILES[@]}"; do
   COMPOSE_FILES_PREFIXED+=("-f" "$file")

--- a/compose/bin/docker-compose
+++ b/compose/bin/docker-compose
@@ -6,16 +6,19 @@ else
   DOCKER_COMPOSE="docker-compose"
 fi
 
-COMPOSE_FILES_LIST=("compose.yaml" "compose.healthcheck.yaml")
+COMPOSE_FILES=("compose.yaml" "compose.healthcheck.yaml")
 
 if [ "$1" == "--no-dev" ]; then
   # ensure --no-dev parameter isn't passed to docker compose
   shift 1
 else
-  COMPOSE_FILES_LIST+=("compose.dev.yaml")
+  COMPOSE_FILES+=("compose.dev.yaml")
 fi
 
-# Combine files, prefix each with -f
-COMPOSE_FILES="${COMPOSE_FILES_LIST[@]/#/'-f '}"
+COMPOSE_FILES_PREFIXED=()
 
-${DOCKER_COMPOSE} ${COMPOSE_FILES} "$@"
+for file in "${COMPOSE_FILES[@]}"; do
+  COMPOSE_FILES_PREFIXED+=("-f" "$file")
+done
+
+${DOCKER_COMPOSE} "${COMPOSE_FILES_PREFIXED[@]}" "$@"

--- a/compose/bin/docker-compose
+++ b/compose/bin/docker-compose
@@ -6,8 +6,16 @@ else
   DOCKER_COMPOSE="docker-compose"
 fi
 
+COMPOSE_FILES_LIST=("compose.yaml" "compose.healthcheck.yaml")
+
 if [ "$1" == "--no-dev" ]; then
-  ${DOCKER_COMPOSE} -f compose.yaml -f compose.healthcheck.yaml "${@:2}"
+  # ensure --no-dev parameter isn't passed to docker compose
+  shift 1
 else
-  ${DOCKER_COMPOSE} -f compose.yaml -f compose.healthcheck.yaml -f compose.dev.yaml "$@"
+  COMPOSE_FILES_LIST+=("compose.dev.yaml")
 fi
+
+# Combine files, prefix each with -f
+COMPOSE_FILES="${COMPOSE_FILES_LIST[@]/#/'-f '}"
+
+${DOCKER_COMPOSE} ${COMPOSE_FILES} "$@"


### PR DESCRIPTION
This is the first step to allow more flexibility.

For example instead of having blackfire commented out in main compose.yaml.
It could be moved to a separate file and included in the list when feature toggle is enabled.

Something like:

```
if [ ${BLACKFIRE_ENABLED} -eq 1 ]; then
  COMPOSE_FILES_LIST+=("compose.blackfire.yaml")
fi
```

It would allow adding features like https://github.com/markshust/docker-magento/pull/998 the same way.