### PR TITLE
Fix elasticsearch host and port

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ bin/download 2.4.6-p3 community
 #  --opensearch-port="$OPENSEARCH_PORT" \
 #  --search-engine=opensearch \
 # with:
-#  --elasticsearch-host="$OPENSEARCH_HOST" \
-#  --elasticsearch-port="$OPENSEARCH_PORT" \
+#  --elasticsearch-host="$ES_HOST" \
+#  --elasticsearch-port="$ES_PORT" \
 #  --search-engine=elasticsearch7 \
 
 # Run the setup installer for Magento:


### PR DESCRIPTION
I followed the directions when I tried to set up Magento, but when I ran the bin/setup script, I encountered the following issue:
"Could not validate a connection to Elasticsearch. No alive nodes found in your cluster", and I noticed a mistake in the README.md file, which this PR corrects.

![287078243-c9f76d3e-e042-4479-bff8-8e039a262a0f](https://github.com/markshust/docker-magento/assets/43544955/1de4469b-1422-4ac7-b6ec-d0264681f091)

![287078285-5eed6c17-3e1b-4dcd-8f64-053c6090fc0d](https://github.com/markshust/docker-magento/assets/43544955/71d89ea9-faa5-4ee5-9023-9cc4746a0183)

