### PR TITLE
Add edit-hosts script

### DIFF
--- a/compose/bin/edit-hosts
+++ b/compose/bin/edit-hosts
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Set the default editor to nano
+EDITOR=nano
+
+# Check if nano is installed; if not, use vim
+if ! command -v $EDITOR &> /dev/null; then
+  EDITOR=vim
+fi
+
+# Check for the presence of sudo
+if ! command -v sudo &> /dev/null; then
+  echo 'Error: sudo is not installed. Please install sudo or run the script with administrator rights.' >&2
+  exit 1
+fi
+
+# Use sudo if necessary
+sudo_command=""
+[ "$EUID" -ne 0 ] && sudo_command="sudo"
+
+# Start the text editor to edit /etc/hosts
+${sudo_command} ${EDITOR} /etc/hosts


### PR DESCRIPTION
This script is created to simplify editing the /etc/hosts file for local development purposes. It grants an easy way to modify the host's file without directly using sudo or manually navigating to the file. Developers can execute this script to open the host file in the nano text editor, allowing them to add or modify entries as needed. The script checks for administrator rights and prompts for a password if necessary, ensuring proper permissions for editing the system host file.
