### PR TITLE
add dependabot to update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
This should help with keeping github actions up to date.

This should resolve https://github.com/markshust/docker-magento/issues/839