### PR TITLE
Add strace support to PHP 8.2/8.1 Docker image

### DIFF
--- a/images/php/8.1/Dockerfile
+++ b/images/php/8.1/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p /etc/nginx/html /var/www/html /sock \
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 
 RUN apt-get update && apt-get install -y \
+    strace \
     cron \
     default-mysql-client \
     git \

--- a/images/php/8.1/Dockerfile
+++ b/images/php/8.1/Dockerfile
@@ -11,7 +11,6 @@ RUN mkdir -p /etc/nginx/html /var/www/html /sock \
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 
 RUN apt-get update && apt-get install -y \
-    strace \
     cron \
     default-mysql-client \
     git \
@@ -35,6 +34,7 @@ RUN apt-get update && apt-get install -y \
     msmtp \
     nodejs \
     procps \
+    strace \
     vim \
     zip \
   && rm -rf /var/lib/apt/lists/*

--- a/images/php/8.2/Dockerfile
+++ b/images/php/8.2/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p /etc/nginx/html /var/www/html /sock \
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 
 RUN apt-get update && apt-get install -y \
+    strace \
     cron \
     default-mysql-client \
     git \

--- a/images/php/8.2/Dockerfile
+++ b/images/php/8.2/Dockerfile
@@ -11,7 +11,6 @@ RUN mkdir -p /etc/nginx/html /var/www/html /sock \
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
 
 RUN apt-get update && apt-get install -y \
-    strace \
     cron \
     default-mysql-client \
     git \
@@ -35,6 +34,7 @@ RUN apt-get update && apt-get install -y \
     msmtp \
     nodejs \
     procps \
+    strace \
     vim \
     zip \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR adds support for strace to the PHP 8.2/8.1 Docker image. The strace tool is included to help troubleshoot potential issues related to consumers running out of control, as outlined in the [GitHub issue](https://github.com/markshust/docker-magento/issues/983).