### PR TITLE
Show a message to the user that they have a failed install

### DIFF
--- a/compose/bin/download
+++ b/compose/bin/download
@@ -3,6 +3,11 @@
 VERSION=${1:-2.4.6-p3}
 EDITION=${2:-community}
 
+# Define ANSI escape codes for colors
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
 bin/stop
 
 bin/start --no-dev
@@ -24,5 +29,8 @@ else
   bin/clinotty composer create-project --repository=https://repo.magento.com/ magento/project-"${EDITION}"-edition="${VERSION}" .
 fi
 
-bin/clinotty [ ! -f "./var/composer_home/auth.json" ] && bin/clinotty mkdir -p ./var/composer_home && bin/clinotty cp /var/www/.composer/auth.json ./var/composer_home/auth.json
-
+if [ $? != 0 ]; then
+    echo -e "${BLUE}Please check the installation guide at ${YELLOW}https://github.com/markshust/docker-magento#install-fails-because-project-directory-is-not-empty${BLUE} for troubleshooting.${NC}"
+else
+    bin/clinotty [ ! -f "./var/composer_home/auth.json" ] && bin/clinotty mkdir -p ./var/composer_home && bin/clinotty cp /var/www/.composer/auth.json ./var/composer_home/auth.json
+fi


### PR DESCRIPTION
### Issue:
Users frequently encounter the "Project directory "/var/www/html/." is not empty" error during installation, leading to numerous GitHub issues.

### Changes Made:
Implemented a detection mechanism during bin/download to identify the presence of the errors. The message guides them to refer to [this link](https://github.com/markshust/docker-magento#install-fails-because-project-directory-is-not-empty) on GitHub for more information on resolving the [issue](https://github.com/markshust/docker-magento/issues/823).

### Additional Notes:

The prompt aims to improve user experience by proactively addressing common installation challenges.
The provided link contains detailed information on troubleshooting and resolving the specified errors.

![Screenshot_2024-01-01_21-26-41](https://github.com/markshust/docker-magento/assets/43544955/37ac56a6-b288-42ff-bdfc-670f7414e948)
