### PR TITLE
bin/log command added

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ It is recommended to keep your root docker config files in one repository, and y
 - `bin/fixperms`: This will fix filesystem permissions within the container.
 - `bin/grunt`: Run the grunt binary. Ex. `bin/grunt exec`
 - `bin/install-php-extensions`: Install PHP extension in the container. Ex. `bin/install-php-extensions sourceguardian`
+- `bin/log`: Monitor the Magento log files. Pass no params to tail all files. Ex. `bin/log debug.log`
 - `bin/magento`: Run the Magento CLI. Ex: `bin/magento cache:flush`
 - `bin/mftf`: Run the Magento MFTF. Ex: `bin/mftf build:project`
 - `bin/mysql`: Run the MySQL CLI with database config from `env/db.env`. Ex. `bin/mysql -e "EXPLAIN core_config_data"` or`bin/mysql < magento.sql`

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -35,6 +35,7 @@ help:
 	@echo "$(call format,fixowns,'This will fix filesystem ownerships within the container.')"
 	@echo "$(call format,fixperms,'This will fix filesystem permissions within the container.')"
 	@echo "$(call format,grunt,'Run the grunt binary.')"
+	@echo "$(call format,log,'Monitor the Magento log files. Pass no params to tail all files.')"
 	@echo "$(call format,magento,'Run the Magento CLI.')"
 	@echo "$(call format,mftf,'Run the Magento MFTF.')"
 	@echo "$(call format,mysql,'Run the MySQL CLI with database config from env/db.env.')"

--- a/compose/bin/log
+++ b/compose/bin/log
@@ -17,30 +17,30 @@ Options:
 }
 
 generate_logs_file_path() {
-  CONTAINER_LOG_PATH="$1"
-  LOG_FILES="$2"
+  local container_log_path="$1"
+  shift  # This shifts the positional parameters to the left, so $2 becomes $1, $3 becomes $2, etc.
+  local log_files=("$@")
+  local log_file_paths=()
 
-  log_file_paths=""
-
-  for file in $LOG_FILES; do
-    log_file_paths+="$CONTAINER_LOG_PATH$file "
+  for file in "${log_files[@]}"; do
+    log_file_paths+=("$container_log_path$file")
   done
 
-  echo "$log_file_paths"
+  echo "${log_file_paths[@]}"
 }
 
 get_all_logs_file_path() {
-  LOGS_LOCATION="$1"
+  local logs_location="$1"
 
-  echo $(bin/docker-compose exec phpfpm ls -p "$LOGS_LOCATION" | grep -v '/$' | sed "s|^|$LOGS_LOCATION|");
+  bin/docker-compose exec phpfpm ls -p "$logs_location" | grep -v '/$' | sed "s|^|$logs_location|"
 }
 
 if [[ $1 == "-h" || $1 == "--help" ]]; then
   display_help
 elif [[ -z $1 ]]; then
-  All_LOGS_FILE_PATH=$(get_all_logs_file_path "$CONTAINER_LOG_PATH")
-  bin/docker-compose exec phpfpm tail -f $All_LOGS_FILE_PATH
+  mapfile -t all_logs_file_path < <(get_all_logs_file_path "$CONTAINER_LOG_PATH")
+  bin/docker-compose exec phpfpm tail -f "${all_logs_file_path[@]}"
 else
-  LOGS_FILE_PATH=$(generate_logs_file_path "$CONTAINER_LOG_PATH" "$1")
-  bin/docker-compose exec phpfpm tail -f $LOGS_FILE_PATH
+  mapfile -t logs_file_path < <(generate_logs_file_path "$CONTAINER_LOG_PATH" "$@")
+  bin/docker-compose exec phpfpm tail -f "${logs_file_path[@]}"
 fi

--- a/compose/bin/log
+++ b/compose/bin/log
@@ -16,7 +16,7 @@ Usage:
   bin/log <specific_log_files>
 
 Arguments:
-  specific_log_files  If specific_log_files NOT provided, show all logs. Ex: bin/log system.log cache.log
+  specific_log_files  If specific_log_files are NOT provided, show all logs. Ex: bin/log system.log cache.log
 
 Options:
   -h, --help          Display help message"

--- a/compose/bin/log
+++ b/compose/bin/log
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+[ -z "$1" ] && echo "Please specify a CLI command (ex. ls)" && exit
+bin/docker-compose exec phpfpm "$@"
+
+#!/bin/bash
+
+source bin/vars/color-vars
+
+CONTAINER_LOG_PATH="/var/www/html/var/log/";
+
+display_help() {
+  echo -e "Description:
+  Tail logs from the Magento var/log folder all and specific logs
+
+Usage:
+  bin/log <specific_log_files>
+
+Arguments:
+  specific_log_files  If specific_log_files NOT provided, show all logs. Ex: bin/log system.log cache.log
+
+Options:
+  -h, --help          Display help message"
+}
+
+generate_logs_file_path() {
+  CONTAINER_LOG_PATH="$1"
+  LOG_FILES="$2"
+
+  log_file_paths=""
+
+  for file in $LOG_FILES; do
+    log_file_paths+="$CONTAINER_LOG_PATH$file "
+  done
+
+  echo "$log_file_paths"
+}
+
+get_all_logs_file_path() {
+  LOGS_LOCATION="$1"
+
+  echo $(bin/docker-compose exec phpfpm ls -p "$LOGS_LOCATION" | grep -v '/$' | sed "s|^|$LOGS_LOCATION|");
+}
+
+if [[ $1 == "-h" || $1 == "--help" ]]; then
+  display_help
+elif [[ -z $1 ]]; then
+  All_LOGS_FILE_PATH=$(get_all_logs_file_path "$CONTAINER_LOG_PATH")
+  bin/docker-compose exec phpfpm tail -f $All_LOGS_FILE_PATH
+else
+  LOGS_FILE_PATH=$(generate_logs_file_path "$CONTAINER_LOG_PATH" "$1")
+  bin/docker-compose exec phpfpm tail -f $LOGS_FILE_PATH
+fi

--- a/compose/bin/log
+++ b/compose/bin/log
@@ -1,10 +1,4 @@
 #!/usr/bin/env bash
-[ -z "$1" ] && echo "Please specify a CLI command (ex. ls)" && exit
-bin/docker-compose exec phpfpm "$@"
-
-#!/bin/bash
-
-source bin/vars/color-vars
 
 CONTAINER_LOG_PATH="/var/www/html/var/log/";
 


### PR DESCRIPTION
It's the new command **bin/log** that tail logs from the Magento var/log folder all and specific logs. 

Usage:
**bin/log** _<specific_log_files>_

Arguments:
**specific_log_files** If specific_log_files are NOT provided, show all logs. 
Example: 
```shell
bin/log system.log cache.log
```

Options:
_-h, --help_  Display help message