### PR TITLE
Pin Docker Compose v2.6.6

### DIFF
--- a/images/php/8.1/Dockerfile
+++ b/images/php/8.1/Dockerfile
@@ -93,7 +93,7 @@ RUN git clone --branch v0.4.15 --depth=1 https://github.com/NoiseByNorthwest/php
     && make install
 
 RUN curl -sS https://getcomposer.org/installer | \
-  php -- --install-dir=/usr/local/bin --filename=composer
+  php -- --version=2.6.6 --install-dir=/usr/local/bin --filename=composer
 
 COPY conf/blackfire.ini $PHP_INI_DIR/conf.d/blackfire.ini
 COPY conf/spx.ini $PHP_INI_DIR/conf.d/spx.ini

--- a/images/php/8.2/Dockerfile
+++ b/images/php/8.2/Dockerfile
@@ -95,7 +95,6 @@ RUN git clone --branch v0.4.15 --depth=1 https://github.com/NoiseByNorthwest/php
 RUN curl -sS https://getcomposer.org/installer | \
   php -- --version=2.6.6 --install-dir=/usr/local/bin --filename=composer
 
-
 COPY conf/blackfire.ini $PHP_INI_DIR/conf.d/blackfire.ini
 COPY conf/spx.ini $PHP_INI_DIR/conf.d/spx.ini
 COPY conf/msmtprc /etc/msmtprc

--- a/images/php/8.2/Dockerfile
+++ b/images/php/8.2/Dockerfile
@@ -93,7 +93,8 @@ RUN git clone --branch v0.4.15 --depth=1 https://github.com/NoiseByNorthwest/php
     && make install
 
 RUN curl -sS https://getcomposer.org/installer | \
-  php -- --install-dir=/usr/local/bin --filename=composer
+  php -- --version=2.6.6 --install-dir=/usr/local/bin --filename=composer
+
 
 COPY conf/blackfire.ini $PHP_INI_DIR/conf.d/blackfire.ini
 COPY conf/spx.ini $PHP_INI_DIR/conf.d/spx.ini

--- a/images/php/8.3/Dockerfile
+++ b/images/php/8.3/Dockerfile
@@ -104,7 +104,7 @@ RUN git clone --branch v0.4.15 --depth=1 https://github.com/NoiseByNorthwest/php
     && make install
 
 RUN curl -sS https://getcomposer.org/installer | \
-  php -- --install-dir=/usr/local/bin --filename=composer
+  php -- --version=2.6.6 --install-dir=/usr/local/bin --filename=composer
 
 COPY conf/blackfire.ini $PHP_INI_DIR/conf.d/blackfire.ini
 COPY conf/spx.ini $PHP_INI_DIR/conf.d/spx.ini


### PR DESCRIPTION
Magento's composer plugin hasn't been updated in over a year, they merged a composer 7 fix but haven't released it... So we'll pin the version for now.

https://github.com/magento/composer-root-update-plugin/issues/40