### PR TITLE
Fix video lesson links to include new Code Quality Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Set Up a Magento 2 Development Environment with Docker
 
 - <a href="https://courses.m.academy/courses/set-up-magento-2-development-environment-docker/lectures/52640115" target="_blank">Configure PHPCS (PHP CodeSniffer) for Magento</a>
 - <a href="https://courses.m.academy/courses/set-up-magento-2-development-environment-docker/lectures/52642491" target="_blank">Configure PHPCSF (PHP CodeSniffer Fixer) for Magento</a>
-- <a href="https://courses.m.academy/courses/set-up-magento-2-development-environment-docker/lectures/52643314" Configure PHPMD (PHP Mess Detector) for Magento</a>
+- <a href="https://courses.m.academy/courses/set-up-magento-2-development-environment-docker/lectures/52643314" target="_blank">Configure PHPMD (PHP Mess Detector) for Magento</a>
 
 #### Xdebug
 


### PR DESCRIPTION
Hi, @markshust

I noticed that in this [commit](https://github.com/markshust/docker-magento/commit/8bfb9469ed70671f0b5b115ff3c74b0b15700018) you updated video lesson links to include new Code Quality Tools, but it is shown incorrectly:
 
![Screenshot from 2024-03-24 20-49-17](https://github.com/markshust/docker-magento/assets/43544955/3ef300c3-5416-45a3-bacf-ff214b986f6f)

This PR fixes the Code Quality Tools list in the `README.md` file.

