### PR TITLE
Removes obsolete `version` directive from docker compose files

### DIFF
--- a/compose/compose.dev-linux.yaml
+++ b/compose/compose.dev-linux.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     volumes: &appvolumes

--- a/compose/compose.dev-ssh.yaml
+++ b/compose/compose.dev-ssh.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     volumes: &appvolumes

--- a/compose/compose.dev.yaml
+++ b/compose/compose.dev.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     volumes: &appvolumes

--- a/compose/compose.healthcheck.yaml
+++ b/compose/compose.healthcheck.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   app:
     healthcheck:

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -10,8 +10,6 @@
 ## 172.17.0.1 in this file with the result of:
 ## docker network inspect bridge --format='{{(index .IPAM.Config 0).Gateway}}'
 
-version: "3"
-
 services:
   app:
     image: markoshust/magento-nginx:1.24-0
@@ -116,14 +114,14 @@ services:
     image: sj26/mailcatcher
     ports:
       - "1080:1080"
-  
+
   ## Cloudflare tunnel support, uncomment to enable
   #tunnel:
   #  container_name: cloudflared-tunnel
   #  image: cloudflare/cloudflared:latest
   #  command: tunnel run
   #  env_file: env/cloudflare.env
-  
+
   ## Blackfire support, uncomment to enable
   #blackfire:
   #  image: blackfire/blackfire:2


### PR DESCRIPTION
Latest version of docker compose started throwing a **WARN[0000]** notification about `version` being obsolete.

https://github.com/docker/compose/issues/11628