### PR TITLE
Fix incorrect links for the one-line and bin/update scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ mkdir -p ~/Sites/magento
 cd $_
 
 # Run this automated one-liner from the directory you want to install your project.
-curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/onelinesetup | bash -s -- magento.test 2.4.7 community
+curl -s https://raw.githubusercontent.com/markshust/docker-magento/release/next/lib/onelinesetup | bash -s -- magento.test 2.4.7 community
 ```
 
 The `magento.test` above defines the hostname to use, and the `2.4.7` defines the Magento version to install. Note that since we need a write to `/etc/hosts` for DNS resolution, you will be prompted for your system password during setup.
@@ -178,7 +178,7 @@ mkdir -p ~/Sites/magento
 cd $_
 
 # Download the Docker Compose template:
-curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/template | bash
+curl -s https://raw.githubusercontent.com/markshust/docker-magento/release/next/lib/template | bash
 
 # Download the version of Magento you want to use with:
 bin/download 2.4.7 community
@@ -218,7 +218,7 @@ mkdir -p ~/Sites/magento
 cd $_
 
 # Download the Docker Compose template:
-curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/template | bash
+curl -s https://raw.githubusercontent.com/markshust/docker-magento/release/next/lib/template | bash
 
 # Take a backup of your existing database:
 bin/mysqldump > ~/Sites/existing/magento.sql

--- a/compose/bin/update
+++ b/compose/bin/update
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit
 mkdir -p tmpupdate && cd "$_"
-curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/template | bash
+curl -s https://raw.githubusercontent.com/markshust/docker-magento/release/next/lib/template | bash
 rm -rf .git
 rsync -av --checksum ./ ../
 cd ..

--- a/lib/onelinesetup
+++ b/lib/onelinesetup
@@ -5,7 +5,7 @@ DOMAIN=${1:-magento.test}
 VERSION=${2:-2.4.6-p4}
 EDITION=${3:-community}
 
-curl -s https://raw.githubusercontent.com/markshust/docker-magento/master/lib/template | bash
+curl -s https://raw.githubusercontent.com/markshust/docker-magento/release/next/lib/template | bash
 
 # &&'s are used below otherwise onelinesetup script fails/errors after bin/download
 bin/download "${VERSION}" "${EDITION}" \

--- a/lib/template
+++ b/lib/template
@@ -2,7 +2,7 @@
 git init -qqq
 git remote add origin https://github.com/markshust/docker-magento
 git fetch origin -qqq
-git checkout origin/master -- compose
+git checkout origin/release/next -- compose
 mv compose/* ./
 mv compose/.gitignore ./
 mv compose/.vscode ./


### PR DESCRIPTION
Fixes #1129 

Now it works as expected.
![Screenshot from 2024-04-18 00-56-37](https://github.com/markshust/docker-magento/assets/43544955/05432d89-1abb-480d-a000-6034ca9c6e1b)
