### PR TITLE
Update Integration testing configuration to use OpenSearch

### DIFF
--- a/compose/template/dev/tests/integration/etc/install-config-mysql.php.2.4.dist
+++ b/compose/template/dev/tests/integration/etc/install-config-mysql.php.2.4.dist
@@ -22,4 +22,5 @@ return [
     'amqp-port' => '5672',
     'amqp-user' => 'magento',
     'amqp-password' => 'magento',
+    'consumers-wait-for-messages' => '0',
 ];

--- a/compose/template/dev/tests/integration/etc/install-config-mysql.php.2.4.dist
+++ b/compose/template/dev/tests/integration/etc/install-config-mysql.php.2.4.dist
@@ -3,6 +3,7 @@
  * Copyright © Magento, Inc. All rights reserved.
  * See COPYING.txt for license details.
  */
+
 return [
     'db-host' => 'db',
     'db-user' => 'magento',
@@ -10,8 +11,8 @@ return [
     'db-name' => 'magento_integration_tests',
     'db-prefix' => '',
     'backend-frontname' => 'backend',
-    'search-engine' => 'elasticsearch7',
-    'elasticsearch-host' => 'elasticsearch',
+    'search-engine' => 'opensearch',
+    'opensearch-host' => 'opensearch',
     'admin-user' => \Magento\TestFramework\Bootstrap::ADMIN_NAME,
     'admin-password' => \Magento\TestFramework\Bootstrap::ADMIN_PASSWORD,
     'admin-email' => \Magento\TestFramework\Bootstrap::ADMIN_EMAIL,


### PR DESCRIPTION
This pull request updates the Integration testing configuration to use OpenSearch, as we have moved from Elasticsearch to OpenSearch.