### PR TITLE
Fix SSL cert generation when domain has a port included

### DIFF
--- a/compose/bin/setup-ssl
+++ b/compose/bin/setup-ssl
@@ -7,7 +7,8 @@ if ! bin/docker-compose exec -T -u root app cat /root/.local/share/mkcert/rootCA
 fi
 
 # Generate the certificate for the specified domain
-bin/docker-compose exec -T -u root app mkcert -key-file nginx.key -cert-file nginx.crt "$@"
+DOMAIN_WITHOUT_PORT=$(echo "$@" | cut -d ':' -f1)
+bin/docker-compose exec -T -u root app mkcert -key-file nginx.key -cert-file nginx.crt "$DOMAIN_WITHOUT_PORT"
 echo "Moving key and cert to /etc/nginx/certs/..."
 bin/docker-compose exec -T -u root app chown app:app nginx.key nginx.crt
 bin/docker-compose exec -T -u root app mv nginx.key nginx.crt /etc/nginx/certs/


### PR DESCRIPTION
This fixes the case where someone tries to run this setup with a domain name that includes a port number

For example, running `bin/setup magento.test:8443`will cause the certificate to fail with an invalid domain name error, since the port should no be included. However, the port should be used in other parts of `bin/setup domain`