### PR TITLE
Add `bin/ece-patches` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ It is recommended to keep your root docker config files in one repository, and y
 - `bin/docker-compose`: Support V1 (`docker-compose`) and V2 (`docker compose`) docker compose command, and use custom configuration files, such as `compose.yml` and `compose.dev.yml`
 - `bin/docker-stats`: Display container name and container ID, status for CPU, memory usage(in MiB and %), and memory limit of currently-running Docker containers.
 - `bin/download`: Download specific Magento version from Composer to the container, with optional arguments of the version (2.4.7 [default]) and type ("community" [default], "enterprise", or "mageos"). Ex. `bin/download 2.4.7 enterprise`
+- `bin/ece-patches`: Run the Cloud Patches CLI. Ex: `bin/ece-tools apply`
 - `bin/fixowns`: This will fix filesystem ownerships within the container.
 - `bin/fixperms`: This will fix filesystem permissions within the container.
 - `bin/grunt`: Run the grunt binary. Ex. `bin/grunt exec`

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -41,6 +41,7 @@ help:
 	@echo "$(call format,docker-compose,'Support V1 (`docker-compose`) and V2 (`docker compose`) docker compose command, and use custom configuration files.')"
 	@echo "$(call format,docker-stats,'Display status for CPU$(comma) memory usage$(comma) and memory limit of currently-running Docker containers.')"
 	@echo "$(call format,download,'Download & extract specific Magento version to the src directory.')"
+	@echo "$(call format,ece-patches,'Run the Cloud Patches CLI.')"
 	@echo "$(call format,fixowns,'This will fix filesystem ownerships within the container.')"
 	@echo "$(call format,fixperms,'This will fix filesystem permissions within the container.')"
 	@echo "$(call format,grunt,'Run the grunt binary.')"

--- a/compose/bin/ece-patches
+++ b/compose/bin/ece-patches
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
+if ! bin/cliq ls vendor/bin/ece-patches; then
+    echo "The ece-patches tool is not installed, make sure you are using Magento Cloud."
+fi
 bin/cli vendor/bin/ece-patches "$@"

--- a/compose/bin/ece-patches
+++ b/compose/bin/ece-patches
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+bin/cli vendor/bin/ece-patches "$@"

--- a/compose/bin/ece-patches
+++ b/compose/bin/ece-patches
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 if ! bin/cliq ls vendor/bin/ece-patches; then
-    echo "The ece-patches tool is not installed, make sure you are using Magento Cloud."
+    echo "The ece-patches tool is not installed. Please ensure you are using Adobe Commerce Cloud before running this command."
 fi
 bin/cli vendor/bin/ece-patches "$@"


### PR DESCRIPTION
## Summary

This PR adds a new command `bin/ece-patches` to enable running Adobe Commerce Cloud patches tool commands from the host inside the container. This addition aims to simplify the process of applying patches by providing a straightforward command.

## Usage

To use the new alias, run the following command from the host:
```shell
bin/ece-patches apply
```
![image](https://github.com/markshust/docker-magento/assets/1055999/23313a58-a3e3-4719-bef6-212213212c3a)

This command will execute the `./vendor/bin/ece-patches` inside the container, allowing you to apply patches as documented in the [Adobe Commerce Cloud Service documentation](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/develop/upgrade/apply-patches#apply-a-patch-in-a-local-environment).