### PR TITLE
Update n98-magerun2 CLI to use a single insert with column names per row

### DIFF
--- a/compose/bin/n98-magerun2
+++ b/compose/bin/n98-magerun2
@@ -11,4 +11,4 @@ if ! bin/cliq ls bin/n98-magerun2.phar; then
   bin/cliq mv n98-magerun2.phar bin
 fi
 
-bin/cli bin/n98-magerun2.phar "$@"
+bin/cli bin/n98-magerun2.phar --human-readable "$@"


### PR DESCRIPTION
Description: Update `n98-magerun2` CLI to use a single insert with column names per row. This change will facilitate easier data searching through the dumped database file.

Details: By default, the `mysqldump` command generates `INSERT` query values on new lines, which complicates data searching through the dumped database file.
For example:
```
zgrep -P "VALUES\s*\(.*\d:\d:...*'" database.sql | awk '{print $3}' | uniq
```
Adding the `--human-readable` option to magerun will enforce a single insert with column names per row (equivalent to `--extended-insert=FALSE` in the `mysqldump` command).

Current:
`bin/cli bin/n98-magerun2.phar "$@"`

Proposed change:
`bin/cli bin/n98-magerun2.phar --human-readable "$@"`