### PR TITLE
Move the option for mysqldump to the appropriate file

### DIFF
--- a/compose/bin/mysqldump
+++ b/compose/bin/mysqldump
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-bin/n98-magerun2 db:dump --stdout "$@"
+bin/n98-magerun2 db:dump --human-readable --stdout "$@"

--- a/compose/bin/n98-magerun2
+++ b/compose/bin/n98-magerun2
@@ -11,4 +11,4 @@ if ! bin/cliq ls bin/n98-magerun2.phar; then
   bin/cliq mv n98-magerun2.phar bin
 fi
 
-bin/cli bin/n98-magerun2.phar --human-readable "$@"
+bin/cli bin/n98-magerun2.phar "$@"


### PR DESCRIPTION
Move the option for `mysqldump` to the appropriate file.

Related PR: https://github.com/markshust/docker-magento/pull/1195