### PR TITLE
Add PHP FTP ext on Docker setup

### DIFF
--- a/images/php/8.2/Dockerfile
+++ b/images/php/8.2/Dockerfile
@@ -56,6 +56,7 @@ RUN docker-php-ext-configure \
     bz2 \
     calendar \
     exif \
+    ftp \
     gd \
     gettext \
     intl \

--- a/images/php/8.3/Dockerfile
+++ b/images/php/8.3/Dockerfile
@@ -67,6 +67,7 @@ RUN docker-php-ext-configure \
     bz2 \
     calendar \
     exif \
+    ftp \
     gd \
     gettext \
     intl \


### PR DESCRIPTION
PHP >= 8.2.15 removed the FTP extension, but Magento still requests its use for FTP configurations. So, I'm adding it to the Docker PHP 8.2 and 8.3 for new builds and upgrades.

Reference: https://github.com/magento/magento2/issues/39083