### PR TITLE
Fix typos in various files

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ open https://magento.test
 OpenSearch is set as the default search engine when setting up this project. Follow the instructions below if you want to use Elasticsearch instead:
 1. Comment out or remove the `opensearch` container in both the [`compose.yaml`](https://github.com/markshust/docker-magento/blob/master/compose/compose.yaml#L69-L84) and [`compose.healthcheck.yaml`](https://github.com/markshust/docker-magento/blob/master/compose/compose.healthcheck.yaml#L36-L41) files
 2. Uncomment the `elasticsearch` container in both the [`compose.yaml`](https://github.com/markshust/docker-magento/blob/master/compose/compose.yaml#L86-L106) and [`compose.healthcheck.yaml`](https://github.com/markshust/docker-magento/blob/master/compose/compose.healthcheck.yaml#L43-L48) files
-3. Update the `bin/setup-install` command to use the Elasticsearch ratther than OpenSearch. Change:
+3. Update the `bin/setup-install` command to use the Elasticsearch rather than OpenSearch. Change:
 
 ```
 --opensearch-host="$OPENSEARCH_HOST" \

--- a/images/php/8.1/conf/php-fpm.conf
+++ b/images/php/8.1/conf/php-fpm.conf
@@ -1,4 +1,4 @@
-; This file was initially adapated from the output of: (on PHP 5.6)
+; This file was initially adapted from the output of: (on PHP 5.6)
 ;   grep -vE '^;|^ *$' /usr/local/etc/php-fpm.conf.default
 
 [global]

--- a/images/php/8.2/conf/php-fpm.conf
+++ b/images/php/8.2/conf/php-fpm.conf
@@ -1,4 +1,4 @@
-; This file was initially adapated from the output of: (on PHP 5.6)
+; This file was initially adapted from the output of: (on PHP 5.6)
 ;   grep -vE '^;|^ *$' /usr/local/etc/php-fpm.conf.default
 
 [global]

--- a/images/php/8.3/conf/php-fpm.conf
+++ b/images/php/8.3/conf/php-fpm.conf
@@ -1,4 +1,4 @@
-; This file was initially adapated from the output of: (on PHP 5.6)
+; This file was initially adapted from the output of: (on PHP 5.6)
 ;   grep -vE '^;|^ *$' /usr/local/etc/php-fpm.conf.default
 
 [global]


### PR DESCRIPTION
Correct typos in various configuration and documentation files.

* **PHP-FPM Configuration Files**:
  - Correct the typo "adapated" to "adapted" in `images/php/8.1/conf/php-fpm.conf`.
  - Correct the typo "adapated" to "adapted" in `images/php/8.2/conf/php-fpm.conf`.
  - Correct the typo "adapated" to "adapted" in `images/php/8.3/conf/php-fpm.conf`.

* **README.md**:
  - Correct the typo "ratther" to "rather".

