### PR TITLE
Switch GitHub Actions to use release/next branch

### DIFF
--- a/.github/workflows/build-elasticsearch-7-16.yml
+++ b/.github/workflows/build-elasticsearch-7-16.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-elasticsearch-8-11.yml
+++ b/.github/workflows/build-elasticsearch-8-11.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-elasticsearch-8-13.yml
+++ b/.github/workflows/build-elasticsearch-8-13.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-elasticsearch-8-4.yml
+++ b/.github/workflows/build-elasticsearch-8-4.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-elasticsearch-8-5.yml
+++ b/.github/workflows/build-elasticsearch-8-5.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-elasticsearch-8-7.yml
+++ b/.github/workflows/build-elasticsearch-8-7.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-nginx-1-18.yml
+++ b/.github/workflows/build-nginx-1-18.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-nginx-1-22.yml
+++ b/.github/workflows/build-nginx-1-22.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-nginx-1-24.yml
+++ b/.github/workflows/build-nginx-1-24.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-opensearch-1-2.yml
+++ b/.github/workflows/build-opensearch-1-2.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-opensearch-2-12.yml
+++ b/.github/workflows/build-opensearch-2-12.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-opensearch-2-5.yml
+++ b/.github/workflows/build-opensearch-2-5.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-php-8-1.yml
+++ b/.github/workflows/build-php-8-1.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-php-8-2.yml
+++ b/.github/workflows/build-php-8-2.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-php-8-3.yml
+++ b/.github/workflows/build-php-8-3.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-php-8-4.yml
+++ b/.github/workflows/build-php-8-4.yml
@@ -1,9 +1,9 @@
-name: build-elasticsearch-7-17
+name: build-php-8-4
 
 on: workflow_dispatch
 
 jobs:
-  elasticsearch-7-17:
+  php-8-3:
     runs-on: ubuntu-latest
     steps:
       -
@@ -19,18 +19,17 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v3 
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
-          context: images/elasticsearch/7.17
+          context: images/php/8.4
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            markoshust/magento-elasticsearch:7.17
-            markoshust/magento-elasticsearch:7.17-1
+            markoshust/magento-php:8.4-fpm-dev

--- a/.github/workflows/build-rabbitmq-3-11.yml
+++ b/.github/workflows/build-rabbitmq-3-11.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-rabbitmq-3-12.yml
+++ b/.github/workflows/build-rabbitmq-3-12.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-rabbitmq-3-13.yml
+++ b/.github/workflows/build-rabbitmq-3-13.yml
@@ -1,9 +1,9 @@
-name: build-elasticsearch-7-17
+name: build-rabbitmq-3-13
 
 on: workflow_dispatch
 
 jobs:
-  elasticsearch-7-17:
+  rabbitmq-3-11:
     runs-on: ubuntu-latest
     steps:
       -
@@ -19,18 +19,18 @@ jobs:
         uses: docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v3 
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
-          context: images/elasticsearch/7.17
+          context: images/rabbitmq/3.13
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            markoshust/magento-elasticsearch:7.17
-            markoshust/magento-elasticsearch:7.17-1
+            markoshust/magento-rabbitmq:3.13
+            markoshust/magento-rabbitmq:3.13-0

--- a/.github/workflows/build-rabbitmq-3-8.yml
+++ b/.github/workflows/build-rabbitmq-3-8.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-rabbitmq-3-9.yml
+++ b/.github/workflows/build-rabbitmq-3-9.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/build-ssh.yml
+++ b/.github/workflows/build-ssh.yml
@@ -9,6 +9,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: release/next
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,30 +1,27 @@
-name: 'ShellCheck'
+name: ShellCheck
 
-on: 
+on:
   push:
     paths:
-    - 'compose/bin/**'
+      - "compose/bin/**"
     branches:
-    - "master"
-
+      - master
   pull_request:
     paths:
-    - 'compose/bin/**'
+      - "compose/bin/**"
 
 jobs:
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-
-    - name: Checkout
-      uses: actions/checkout@v4
-
-    - name: Run ShellCheck
-      uses: ludeeus/action-shellcheck@master
-      id: check
-      env:
-        SHELLCHECK_OPTS: -x -e SC2181 -P compose/bin -P compose/env
-      with:
-        check_together: true
-        scandir: './compose/bin'
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master
+        id: check
+        env:
+          SHELLCHECK_OPTS: "-x -e SC2181 -P compose/bin -P compose/env"
+        with:
+          check_together: true
+          scandir: "./compose/bin"


### PR DESCRIPTION
Switching the build branch from `master` to `release/next` will allow images to be built using the updated README, images, etc. before pushing the images live. It typically takes a few hours for the builds to complete, so this method will allow me to execute the task to build the images, and calmly continue with other tasks (such as updating the CHANGELOG, etc.) while this happens, also knowing that the `compose.yaml` file will continue to function and not fail during this time.