### PR TITLE
Fix: Prevent CDPATH from corrupting directory paths in copy scripts

### DIFF
--- a/compose/bin/copyfromcontainer
+++ b/compose/bin/copyfromcontainer
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 [ -z "$1" ] && echo "Please specify a directory or file to copy from container (ex. vendor, --all)" && exit
 
-REAL_SRC=$(cd -P "src" && pwd)
+REAL_SRC=$(cd -P "src" >/dev/null && pwd)
 if [ ! -d "$REAL_SRC" ]; then
   mkdir -p "$REAL_SRC"
 fi

--- a/compose/bin/copytocontainer
+++ b/compose/bin/copytocontainer
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 [ -z "$1" ] && echo "Please specify a directory or file to copy to container (ex. vendor, --all)" && exit
 
-REAL_SRC=$(cd -P "src" && pwd)
+REAL_SRC=$(cd -P "src" >/dev/null && pwd)
 if [ "$1" == "--all" ]; then
   docker cp "$REAL_SRC/./" "$(bin/docker-compose ps -q phpfpm|awk '{print $1}')":/var/www/html/
   echo "Completed copying all files from host to container"


### PR DESCRIPTION
This PR suppresses output from the `cd` command when setting REAL_SRC in `copyfromcontainer` and `copytocontainer`. This prevents a bug where REAL_SRC is filled with more than one path when the user makes use of a $CDPATH environment variable. [Per `cd`'s man](https://man7.org/linux/man-pages/man1/cd.1p.html#STDOUT):

> If a non-empty directory name from CDPATH is used [...] an absolute pathname of the new working directory shall be writen to the standard output as follows:
> 
>     "%s\n", <new directory>

Redirecting `cd`'s output to `/dev/null` makes sure the variable is only filled with the output from `pwd`.