### PR TITLE
`bin/init` script to initialize development environment with sample data and dev-related modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ It is recommended to keep your root docker config files in one repository, and y
 - `bin/fixowns`: This will fix filesystem ownerships within the container.
 - `bin/fixperms`: This will fix filesystem permissions within the container.
 - `bin/grunt`: Run the grunt binary. Ex. `bin/grunt exec`
+- `bin/init`: Initialize development environment with sample data and dev-related modules.
 - `bin/install-php-extensions`: Install PHP extension in the container. Ex. `bin/install-php-extensions sourceguardian`
 - `bin/log`: Monitor the Magento log files. Pass no params to tail all files. Ex. `bin/log debug.log`
 - `bin/magento`: Run the Magento CLI. Ex: `bin/magento cache:flush`

--- a/README.md
+++ b/README.md
@@ -158,13 +158,12 @@ The `magento.test` above defines the hostname to use, `community` is the Magento
 
 After the one-liner above completes running, you should be able to access your site at `https://magento.test`.
 
-#### Install sample data
+#### Install sample data and development modules
 
-After the above installation is complete, run the following lines to install sample data:
+After the above installation is complete, you can initialize the development environment with sample data and dev-related modules with:
 
 ```bash
-bin/magento sampledata:deploy
-bin/magento setup:upgrade
+bin/init
 ```
 
 ### Manual Setup
@@ -196,6 +195,9 @@ bin/download community 2.4.8-p3
 
 # Run the setup installer for Magento:
 bin/setup magento.test
+
+# Initialize development environment with sample data and dev-related modules:
+bin/init
 
 open https://magento.test
 ```

--- a/compose/Makefile
+++ b/compose/Makefile
@@ -46,6 +46,7 @@ help:
 	@echo "$(call format,fixowns,'This will fix filesystem ownerships within the container.')"
 	@echo "$(call format,fixperms,'This will fix filesystem permissions within the container.')"
 	@echo "$(call format,grunt,'Run the grunt binary.')"
+	@echo "$(call format,init,'Initialize development environment with sample data and dev-related modules.')"
 	@echo "$(call format,install-php-extensions,'Install PHP extension in the container.')"
 	@echo "$(call format,log,'Monitor the Magento log files. Pass no params to tail all files.')"
 	@echo "$(call format,magento,'Run the Magento CLI.')"

--- a/compose/bin/init
+++ b/compose/bin/init
@@ -7,15 +7,16 @@ set -e
 
 echo ">>> Deploying Magento sample data..."
 bin/magento sampledata:deploy
-bin/magento setup:upgrade
 
 echo ">>> Disabling Two-Factor Authentication (for dev only)..."
 bin/composer require --dev markshust/magento2-module-disabletwofactorauth
 bin/magento module:enable MarkShust_DisableTwoFactorAuth
+
+echo ">>> Running setup upgrade (applies sample data + new modules)..."
 bin/magento setup:upgrade
-bin/magento config:set twofactorauth/general/enable 0
 
 echo ">>> Setting long admin session lifetime (1 year)..."
+bin/magento config:set twofactorauth/general/enable 0
 bin/magento config:set admin/security/session_lifetime 31536000
 
 echo ">>> Generating URN catalog for IDEs..."
@@ -23,7 +24,7 @@ bin/dev-urn-catalog-generate
 
 echo ">>> Running final optimizations (compile, reindex, cache flush)..."
 bin/magento setup:di:compile
-bin/magento index:reindex
+bin/magento indexer:reindex
 bin/magento cache:flush
 
 echo ">>> Magento development environment initialized successfully! 🎉"

--- a/compose/bin/init
+++ b/compose/bin/init
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Script to initialize a Magento development environment
+
+# Exit immediately if a command fails
+set -e
+
+echo ">>> Deploying Magento sample data..."
+bin/magento sampledata:deploy
+bin/magento setup:upgrade
+
+echo ">>> Disabling Two-Factor Authentication (for dev only)..."
+bin/composer require --dev markshust/magento2-module-disabletwofactorauth
+bin/magento module:enable MarkShust_DisableTwoFactorAuth
+bin/magento setup:upgrade
+bin/magento config:set twofactorauth/general/enable 0
+
+echo ">>> Setting long admin session lifetime (1 year)..."
+bin/magento config:set admin/security/session_lifetime 31536000
+
+echo ">>> Generating URN catalog for IDEs..."
+bin/dev-urn-catalog-generate
+
+echo ">>> Running final optimizations (compile, reindex, cache flush)..."
+bin/magento setup:di:compile
+bin/magento index:reindex
+bin/magento cache:flush
+
+echo ">>> Magento development environment initialized successfully! 🎉"


### PR DESCRIPTION
This PR adds a new `init` script to simplify Magento local environment setup.

### Includes
- Deploys sample data
- Disables Two-Factor Authentication (dev only)
- Sets long admin session lifetime
- Generates URN catalog

### Purpose
Streamlines the initialization process for local development, reducing manual steps.
