### PR TITLE
Fix: avoid 'Warning: magento.env file not found' when running bin/setup

### DIFF
--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -o errexit
-if [ -f "../env/magento.env" ]; then
+if [ -f "./env/magento.env" ]; then
+    source "./env/magento.env"
+elif [ -f "../env/magento.env" ]; then
     source "../env/magento.env"
 else
     echo "Warning: magento.env file not found."


### PR DESCRIPTION
### Summary

Previously, the setup script only checked for `../env/magento.env`.  
As a result, when the `magento.env` file was located in `./env`, the script showed the warning:

<img width="1391" height="403" alt="image" src="https://github.com/user-attachments/assets/0e17521e-83c9-49ed-99cf-a1b9338ea7d4" />

Also, when the env file was not found, the admin credentials did not appear in the output:

<img width="720" height="108" alt="image" src="https://github.com/user-attachments/assets/c4088999-59de-4cba-bfa8-51cab52ceaf5" />


### Changes

- Added a check for `./env/magento.env` before checking `../env/magento.env`.
- This ensures the environment file is sourced correctly.

### Result
- The warning no longer appears when the file exists in the current directory.
- The admin credentials are now displayed correctly after setup:

<img width="654" height="124" alt="image" src="https://github.com/user-attachments/assets/3e282855-8c90-4fe5-a3f8-c6fad5ef0568" />