### PR TITLE
Source env files relative to script path in bin scripts

### DIFF
--- a/compose/bin/mysql
+++ b/compose/bin/mysql
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
+ENV_DIR="$(dirname "$0")/../env"
 # shellcheck source=../env/db.env
-source env/db.env
+source "$ENV_DIR/db.env"
 if [ -t 0 ]; then
   # Need tty to run mysql shell
   bin/cli mysql -h"${MYSQL_HOST}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" "${MYSQL_DATABASE}" "$@"

--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -o errexit
-if [ -f "../env/magento.env" ]; then
-    source "../env/magento.env"
+if [ -f "$(dirname "$0")/../env/magento.env" ]; then
+    source "$(dirname "$0")/../env/magento.env"
 else
     echo "Warning: magento.env file not found."
 fi

--- a/compose/bin/setup
+++ b/compose/bin/setup
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 set -o errexit
-if [ -f "$(dirname "$0")/../env/magento.env" ]; then
-    source "$(dirname "$0")/../env/magento.env"
+ENV_DIR="$(dirname "$0")/../env"
+if [ -f "$ENV_DIR/magento.env" ]; then
+    # shellcheck source=../env/magento.env
+    source "$ENV_DIR/magento.env"
 else
     echo "Warning: magento.env file not found."
 fi

--- a/compose/bin/setup-install
+++ b/compose/bin/setup-install
@@ -3,18 +3,19 @@ set -o errexit
 
 DOMAIN=${1:-magento.test}
 
+ENV_DIR="$(dirname "$0")/../env"
 # shellcheck source=../env/db.env
-source env/db.env
+source "$ENV_DIR/db.env"
 # shellcheck source=../env/elasticsearch.env
-source env/elasticsearch.env
+source "$ENV_DIR/elasticsearch.env"
 # shellcheck source=../env/opensearch.env
-source env/opensearch.env
+source "$ENV_DIR/opensearch.env"
 # shellcheck source=../env/magento.env
-source env/magento.env
+source "$ENV_DIR/magento.env"
 # shellcheck source=../env/rabbitmq.env
-source env/rabbitmq.env
+source "$ENV_DIR/rabbitmq.env"
 # shellcheck source=../env/redis.env
-source env/redis.env
+source "$ENV_DIR/redis.env"
 
 bin/clinotty bin/magento setup:install \
   --db-host="$MYSQL_HOST" \

--- a/compose/bin/setup-integration-tests
+++ b/compose/bin/setup-integration-tests
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
+ENV_DIR="$(dirname "$0")/../env"
 # shellcheck source=../env/db.env
-source env/db.env
+source "$ENV_DIR/db.env"
 
 MYSQL_INTEGRATION_CONFIG=dev/tests/integration/etc/install-config-mysql.php
 


### PR DESCRIPTION
When following the [installation instructions](https://github.com/markshust/docker-magento?tab=readme-ov-file#new-projects) from the readme, running `bin/setup` yields a warning `magento.env file not found`. This is because the environment is sourced from `../env/magento.env`, and assuming we're running the script in `$PWD`, it is trying to source the env from `$PWD/../env/magento.env`, while the file is in `$PWD/env/magento.env` (assuming we didn't `cd` into `bin/`).

The original fix changed `bin/setup` to prepend the path with the script dir so it always finds `magento.env` regardless of the working directory. This is also probably a more durable solution than the one proposed in #1385.

## Update — extended for consistency

The same cwd-dependent sourcing pattern existed in `bin/setup-install`, `bin/setup-integration-tests`, and `bin/mysql` (all using `source env/<file>.env`). To keep the bin scripts consistent and avoid the same class of bug surfacing elsewhere, this PR now applies a script-relative `ENV_DIR` to all four scripts:

```bash
ENV_DIR="$(dirname "$0")/../env"
# shellcheck source=../env/db.env
source "$ENV_DIR/db.env"
```

This pattern:
- Works regardless of the user's `cwd` when invoking the script
- Preserves the existing `# shellcheck source=...` directives so ShellCheck CI still follows the env files for full variable lint coverage
- Keeps the same overall structure as the original code — only the path argument changes

Files updated: `compose/bin/setup`, `compose/bin/setup-install`, `compose/bin/setup-integration-tests`, `compose/bin/mysql`.
