### PR TITLE
Standardize shebangs to `#!/usr/bin/env bash`

### DIFF
--- a/compose/bin/debug-cli
+++ b/compose/bin/debug-cli
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 S=$(bin/clinotty cat /usr/local/etc/php/php.ini | grep -iGc 'xdebug.mode = off');
 R=$(grep -c 'XDEBUG_CONFIG=idekey' ./env/phpfpm.env)
 

--- a/compose/bin/init
+++ b/compose/bin/init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to initialize a Magento development environment
 


### PR DESCRIPTION
Most of the bin commands have already been updated in the course of the work discussed here: https://github.com/markshust/docker-magento/issues/864

This PR completes this work by updating the last two remaining files to ensure consistent use of shebang throughout the project.