### PR TITLE
Refactor copy scripts to reuse resolved container ID

### DIFF
--- a/compose/bin/copyfromcontainer
+++ b/compose/bin/copyfromcontainer
@@ -1,18 +1,20 @@
 #!/usr/bin/env bash
 [ -z "$1" ] && echo "Please specify a directory or file to copy from container (ex. vendor, --all)" && exit
 
+CONTAINER_ID=$(bin/docker-compose ps -q phpfpm | awk '{print $1}')
 REAL_SRC=$(cd -P "src" >/dev/null && pwd)
 if [ ! -d "$REAL_SRC" ]; then
   mkdir -p "$REAL_SRC"
 fi
+
 if [ "$1" == "--all" ]; then
-  docker cp "$(bin/docker-compose ps -q phpfpm|awk '{print $1}')":/var/www/html/./ "$REAL_SRC/"
+  docker cp "$CONTAINER_ID":/var/www/html/./ "$REAL_SRC/"
   echo "Completed copying all files from container to host"
 else
   if [ -f "$1" ] ; then
-    docker cp "$(bin/docker-compose ps -q phpfpm|awk '{print $1}')":/var/www/html/"$1" "$REAL_SRC/$1"
+    docker cp "$CONTAINER_ID":/var/www/html/"$1" "$REAL_SRC/$1"
   else
-    docker cp "$(bin/docker-compose ps -q phpfpm|awk '{print $1}')":/var/www/html/"$1" "$REAL_SRC/$(dirname "$1")"
+    docker cp "$CONTAINER_ID":/var/www/html/"$1" "$REAL_SRC/$(dirname "$1")"
   fi
   echo "Completed copying $1 from container to host"
 fi

--- a/compose/bin/copytocontainer
+++ b/compose/bin/copytocontainer
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 [ $# -eq 0 ] && echo "Please specify one or more directories/files to copy to container (ex. vendor, --all)" && exit 1
 
-REAL_SRC=$(cd -P "src" >/dev/null && pwd)
 CONTAINER_ID=$(bin/docker-compose ps -q phpfpm | awk '{print $1}')
+REAL_SRC=$(cd -P "src" >/dev/null && pwd)
 
 for ARG in "$@"; do
   if [ "$ARG" == "--all" ]; then


### PR DESCRIPTION
This PR refactors `bin/copyfromcontainer` and `bin/copytocontainer` to resolve the `phpfpm` container ID once and reuse it instead of executing:
```
bin/docker-compose ps -q phpfpm | awk '{print $1}'
```
multiple times.