### PR TITLE
Update README.md Composer Auth DevDoc Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ bin/mysqldump > magento.sql
 
 ### Composer Authentication
 
-First setup Magento Marketplace authentication (details in the [DevDocs](http://devdocs.magento.com/guides/v2.0/install-gde/prereq/connect-auth.html)).
+First setup Magento Marketplace authentication (details in the [DevDocs](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/prerequisites/authentication-keys)).
 
 Copy `src/auth.json.sample` to `src/auth.json`. Then, update the username and password values with your Magento public and private keys, respectively. Finally, copy the file to the container by running `bin/copytocontainer auth.json`.
 


### PR DESCRIPTION
Previous link no longer works. New link directs users to the Commerce Marketplace and should be straight forward from there.