### PR TITLE
Fix Docker image by updating Debian base and SSH setup

### DIFF
--- a/images/ssh/Dockerfile
+++ b/images/ssh/Dockerfile
@@ -1,16 +1,18 @@
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 ARG APP_ID=1000
 
-RUN apt-get update && apt-get install -y ssh
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openssh-server \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -g "$APP_ID" app \
   && useradd -g "$APP_ID" -u "$APP_ID" -d /var/www -s /bin/bash app
 
 RUN echo 'app:app' | chpasswd
 
-RUN service ssh start
+RUN mkdir /var/run/sshd
 
 EXPOSE 22
 
-CMD ["/usr/sbin/sshd","-D"]
+CMD ["/usr/sbin/sshd", "-D"]


### PR DESCRIPTION
This PR fixes the Docker build failure caused by using an unsupported Debian version (buster).

- Updated base image to a supported Debian version
- Fixed apt repository errors
- Switched to openssh-server
- Cleaned up Dockerfile