### PR TITLE
docs: fix stale Blackfire setup instructions (#1336)

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,19 +642,28 @@ vm.max_map_count=262144
 
 ### Blackfire.io
 
-These docker images have built-in support for Blackfire.io. To use it, first register your server ID and token with the Blackfire agent:
+These docker images have built-in support for Blackfire.io. The Blackfire probe is already installed in the PHP image; the Blackfire agent runs as a separate sidecar container.
 
-```
-bin/root blackfire-agent --register --server-id={YOUR_SERVER_ID} --server-token={YOUR_SERVER_TOKEN}
-```
+To enable it:
 
-Next, open up the `bin/start` helper script and uncomment the line:
+1. Uncomment the `blackfire` service in `compose.yaml`.
+2. Add your server credentials to `env/blackfire.env`:
 
-```
-#bin/root /etc/init.d/blackfire-agent start
-```
+    ```
+    BLACKFIRE_SERVER_ID={YOUR_SERVER_ID}
+    BLACKFIRE_SERVER_TOKEN={YOUR_SERVER_TOKEN}
+    ```
 
-Finally, restart the containers with `bin/restart`. After doing so, everything is now configured and you can use a browser extension to profile your Magento store with Blackfire.
+3. Add your client credentials to `env/phpfpm.env`:
+
+    ```
+    BLACKFIRE_CLIENT_ID={YOUR_CLIENT_ID}
+    BLACKFIRE_CLIENT_TOKEN={YOUR_CLIENT_TOKEN}
+    ```
+
+4. Restart the containers with `bin/restart`.
+
+After doing so, everything is configured and you can use a browser extension to profile your Magento store with Blackfire.
 
 ### Cloudflare Tunnel
 

--- a/compose/bin/start
+++ b/compose/bin/start
@@ -61,10 +61,10 @@ bin/docker-compose up -d --remove-orphans "$@"
 
 ## Blackfire support
 ## ------------------
-## First register the blackfire agent with:
-#bin/root blackfire-agent --register --server-id={YOUR_SERVER_ID} --server-token={YOUR_SERVER_TOKEN}
-## Then uncomment the below line (and leave uncommented) to start the agent automatically with bin/start:
-#bin/root /etc/init.d/blackfire-agent start
+## The Blackfire probe is built into the PHP image. The agent runs as a sidecar
+## container — uncomment the `blackfire` service in compose.yaml and set
+## BLACKFIRE_SERVER_ID / BLACKFIRE_SERVER_TOKEN in env/blackfire.env, plus
+## BLACKFIRE_CLIENT_ID / BLACKFIRE_CLIENT_TOKEN in env/phpfpm.env.
 
 # Check if cron was previously enabled and restart it if needed
 if bin/cli test -f /var/www/html/var/.cron-enabled; then


### PR DESCRIPTION
## Summary
- Closes #1336
- Rewrite the README "Blackfire.io" section and the `bin/start` comment block to describe the current sidecar-based setup. The old instructions told users to run `blackfire-agent --register` and `/etc/init.d/blackfire-agent start` inside the PHP container, but the agent isn't installed there — it runs as the `blackfire/blackfire:2` service already stubbed in `compose.yaml`.
- No image or runtime changes; the Blackfire probe and `blackfire.ini` are already shipped in the PHP Dockerfiles.

## Test plan
- [ ] Read through the new README "Blackfire.io" section end-to-end and confirm the 4 steps match `compose.yaml`, `env/blackfire.env`, and `env/phpfpm.env`
- [ ] Spot-check `compose/bin/start` comment block renders sensibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)