### PR TITLE
docs: document multi-storefront / multi-domain setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,6 +640,70 @@ Add the following line to the `/etc/sysctl.conf` file on your host:
 vm.max_map_count=262144
 ```
 
+### Multi-storefront / multi-domain setup
+
+Magento supports running multiple storefronts from a single codebase by setting `MAGE_RUN_CODE` and `MAGE_RUN_TYPE` per request. There are two common ways to do this locally; pick whichever matches how your production environment is wired. Both rely on the [`compose.override.yaml`](#persisting-local-compose-changes-across-updates) mechanism so your customizations survive `bin/update`.
+
+#### Option 1: nginx `map` (recommended for most setups)
+
+Map each hostname to a run code in an nginx snippet, then mount it into the `app` container via `compose.override.yaml`:
+
+```nginx
+# store.map.conf
+map $http_host $MAGE_RUN_CODE {
+    store1.example.test  store1_view;
+    store2.example.test  store2_view;
+    default              default;
+}
+```
+
+```yaml
+# compose.override.yaml
+services:
+  app:
+    volumes:
+      - ./store.map.conf:/etc/nginx/conf.d/store.map.conf:cached
+```
+
+Add the hostnames to `/etc/hosts` and run `bin/setup-ssl store1.example.test store2.example.test`.
+
+#### Option 2: `magento-vars.php` (Adobe Commerce Cloud parity)
+
+If your production environment runs on Adobe Commerce Cloud, it likely uses a `magento-vars.php` file at the project root that's loaded via PHP's `auto_prepend_file`. To mirror that locally, create `src/magento-vars.php` and `src/php.ini`, then wire them up with `compose.override.yaml`:
+
+```php
+// src/magento-vars.php
+<?php
+function isHttpHost(string $host): bool {
+    return ($_SERVER['HTTP_HOST'] ?? '') === $host;
+}
+
+if (isHttpHost('store1.example.test')) {
+    $_SERVER['MAGE_RUN_CODE'] = 'store1_view';
+    $_SERVER['MAGE_RUN_TYPE'] = 'store';
+}
+```
+
+```ini
+; src/php.ini
+auto_prepend_file = /app/magento-vars.php
+```
+
+```yaml
+# compose.override.yaml
+services:
+  app:
+    volumes:
+      - ./src:/app:cached
+      - ./src/php.ini:/usr/local/etc/php/conf.d/local-php.ini:cached
+  phpfpm:
+    volumes:
+      - ./src:/app:cached
+      - ./src/php.ini:/usr/local/etc/php/conf.d/local-php.ini:cached
+```
+
+The nginx `map` approach is simpler and provider-agnostic; the `magento-vars.php` approach is worth the extra setup only if you specifically need to match Adobe Commerce Cloud's request lifecycle.
+
 ### Blackfire.io
 
 These docker images have built-in support for Blackfire.io. The Blackfire probe is already installed in the PHP image; the Blackfire agent runs as a separate sidecar container.


### PR DESCRIPTION
## Summary

- Adds a new `### Multi-storefront / multi-domain setup` section to the README under `## Misc Info`
- Documents two provider-agnostic approaches:
  1. **nginx `map`** — maps `$http_host` → `MAGE_RUN_CODE` via a mounted nginx snippet (recommended; not tied to any hosting provider)
  2. **`magento-vars.php`** — Adobe Commerce Cloud-style `auto_prepend_file` pattern using `src/magento-vars.php` + `src/php.ini`
- Both approaches are wired up via the existing `compose.override.yaml` mechanism (#1397), so no script or image changes are needed

## Context

This replaces #1430 (which was mistakenly opened against `master`) and closes out #869. With `compose.override.yaml` support in place, users can achieve the original PR's goal with a small local override file — and we'd rather document both common patterns than pick a winner in the script.

Credit to @h3xx for the original Adobe Commerce Cloud-style approach and to @piotrkwiecinski for surfacing the nginx `map` alternative.

## Test plan

- [ ] Render README on GitHub and confirm the new section appears under `## Misc Info`, above `### Blackfire.io`
- [ ] Verify internal anchor link to `#persisting-local-compose-changes-across-updates` resolves
- [ ] Spot-check the YAML / nginx / PHP / ini snippets for typos

🤖 Generated with [Claude Code](https://claude.com/claude-code)