### PR TITLE
feat: add RabbitMQ 4.2 image (prereq for #1432)

### DIFF
--- a/.github/workflows/build-rabbitmq-4-2.yml
+++ b/.github/workflows/build-rabbitmq-4-2.yml
@@ -1,0 +1,39 @@
+name: build-rabbitmq-4-2
+
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  rabbitmq-4-2:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: release/next
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v7
+        with:
+          context: images/rabbitmq/4.2
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            markoshust/magento-rabbitmq:4.2
+            markoshust/magento-rabbitmq:4.2-0

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ View Dockerfiles for the latest tags:
   - [`3.13`, `3.13-0`](images/rabbitmq/3.13)
   - [`4.1`, `4.1-0`](images/rabbitmq/4.1)
   - [`4.2`, `4.2-0`](images/rabbitmq/4.2)
-- Valkey is referenced directly via the upstream `valkey/valkey:*-alpine` tags (e.g. `valkey/valkey:7.2-alpine`, `valkey/valkey:8.1-alpine`, `valkey/valkey:9.1-alpine`) rather than rebuilt under `markoshust/magento-valkey`. Same pattern as `mariadb:*` and `redis:*-alpine` — no Magento-specific configuration is needed, so there is no separate image to maintain.
 - [markoshust/ssh (Docker Hub)](https://hub.docker.com/r/markoshust/magento-ssh/)
   - [`latest`](images/ssh)
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ View Dockerfiles for the latest tags:
   - [`3.12`, `3.12-0`](images/rabbitmq/3.12)
   - [`3.13`, `3.13-0`](images/rabbitmq/3.13)
   - [`4.1`, `4.1-0`](images/rabbitmq/4.1)
+  - [`4.2`, `4.2-0`](images/rabbitmq/4.2)
+- Valkey is referenced directly via the upstream `valkey/valkey:*-alpine` tags (e.g. `valkey/valkey:7.2-alpine`, `valkey/valkey:8.1-alpine`, `valkey/valkey:9.1-alpine`) rather than rebuilt under `markoshust/magento-valkey`. Same pattern as `mariadb:*` and `redis:*-alpine` — no Magento-specific configuration is needed, so there is no separate image to maintain.
 - [markoshust/ssh (Docker Hub)](https://hub.docker.com/r/markoshust/magento-ssh/)
   - [`latest`](images/ssh)
 

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -123,7 +123,7 @@ services:
   #    #- "xpack.security.enabled=false"
 
   rabbitmq:
-    image: markoshust/magento-rabbitmq:4.1-0
+    image: markoshust/magento-rabbitmq:4.2-0
     ports:
       - "15672:15672"
       - "5672:5672"

--- a/images/rabbitmq/4.2/Dockerfile
+++ b/images/rabbitmq/4.2/Dockerfile
@@ -1,0 +1,3 @@
+FROM rabbitmq:4.2-management-alpine
+
+COPY conf/rabbitmq.conf /etc/rabbitmq/rabbitmq.conf

--- a/images/rabbitmq/4.2/conf/rabbitmq.conf
+++ b/images/rabbitmq/4.2/conf/rabbitmq.conf
@@ -1,0 +1,1 @@
+vm_memory_high_watermark.absolute = 1GB


### PR DESCRIPTION
## Summary
Prerequisite for #1432 (auto-detect Magento/Mage-OS version and pin compatible service images). The lookup table in that PR will reference `markoshust/magento-rabbitmq:4.2-0`, which doesn't exist on Docker Hub yet — this PR adds the build artifacts so that tag will be publishable before the main PR lands.

- New `images/rabbitmq/4.2/Dockerfile` + `conf/rabbitmq.conf` mirroring `4.1` (`vm_memory_high_watermark.absolute = 1GB`)
- New `.github/workflows/build-rabbitmq-4-2.yml` `workflow_dispatch` job that builds and pushes `4.2` / `4.2-0` tags for `linux/amd64` + `linux/arm64`
- `compose/compose.yaml` default `rabbitmq` image bumped to `4.2-0` — Adobe's 2.4.7/2.4.8/2.4.9 matrices and Mage-OS's 2.x/3.0 matrices all list RabbitMQ 4.2 as supported
- README image-tag list updated, plus a Valkey upstream-tag policy note documenting that `valkey/valkey:*-alpine` is referenced directly (same pattern as `mariadb:*` and `redis:*-alpine`) rather than rebuilt under `markoshust/magento-valkey`

## Test plan
- [x] `docker build -t test images/rabbitmq/4.2` succeeds
- [x] Container boots; `rabbitmq-diagnostics -q ping` returns `Ping succeeded`
- [x] `rabbitmqctl status` reports RabbitMQ 4.2.6 on Erlang/OTP 27
- [x] `rabbitmq-plugins list -e` confirms `rabbitmq_management` and `rabbitmq_prometheus` are running
- [x] `/etc/rabbitmq/rabbitmq.conf` inside the container matches `images/rabbitmq/4.2/conf/rabbitmq.conf`
- [ ] After merge: trigger `build-rabbitmq-4-2` workflow manually, confirm `markoshust/magento-rabbitmq:4.2` and `:4.2-0` tags appear on Docker Hub
- [ ] After Docker Hub publish: `bin/start` against a fresh checkout pulls the new image cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)