### PR TITLE
fix: make bin/log compatible with Bash 3.2 on macOS (closes #1440)

### DIFF
--- a/compose/bin/log
+++ b/compose/bin/log
@@ -16,19 +16,6 @@ Options:
   -h, --help          Display help message"
 }
 
-generate_logs_file_path() {
-  local container_log_path="$1"
-  shift  # This shifts the positional parameters to the left, so $2 becomes $1, $3 becomes $2, etc.
-  local log_files=("$@")
-  local log_file_paths=()
-
-  for file in "${log_files[@]}"; do
-    log_file_paths+=("$container_log_path$file")
-  done
-
-  echo "${log_file_paths[@]}"
-}
-
 get_all_logs_file_path() {
   local logs_location="$1"
 
@@ -38,9 +25,17 @@ get_all_logs_file_path() {
 if [[ $1 == "-h" || $1 == "--help" ]]; then
   display_help
 elif [[ -z $1 ]]; then
-  mapfile -t all_logs_file_path < <(get_all_logs_file_path "$CONTAINER_LOG_PATH")
+  all_logs_file_path=()
+  while IFS= read -r line; do
+    all_logs_file_path+=("$line")
+  done < <(get_all_logs_file_path "$CONTAINER_LOG_PATH")
+
   bin/docker-compose exec phpfpm tail -f "${all_logs_file_path[@]}"
 else
-  mapfile -t logs_file_path < <(generate_logs_file_path "$CONTAINER_LOG_PATH" "$@")
+  logs_file_path=()
+  for file in "$@"; do
+    logs_file_path+=("${CONTAINER_LOG_PATH}${file}")
+  done
+
   bin/docker-compose exec phpfpm tail -f "${logs_file_path[@]}"
 fi


### PR DESCRIPTION
## Summary
`bin/log` used the `mapfile` builtin (Bash 4+), which fails on stock macOS (Bash 3.2) with `bin/log: line 44: mapfile: command not found` (#1440).

This replaces `mapfile` with portable constructs:
- All-logs branch: `while IFS= read -r` loop
- Specific-files branch: a direct `for` loop building the path array

The latter also fixes a latent bug — the old `generate_logs_file_path` helper `echo`'d all paths onto one space-separated line, so multiple file args (`bin/log system.log cache.log`) collapsed into a single `tail` argument even on Bash 4. The now-unused helper was removed.

## Testing
- `bash -n compose/bin/log` passes
- No Bash 4+ features remain; all constructs work on Bash 3.2

Closes #1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)