### PR TITLE
fix: pin GA-safe MariaDB versions for Magento 2.4.7/2.4.8 (closes #1404)

### DIFF
--- a/compose/lib/versions.tsv
+++ b/compose/lib/versions.tsv
@@ -26,8 +26,8 @@
 #
 # edition	version	php	opensearch	nginx	db	rabbitmq	cache	composer
 magento	2.4.9	8.5-fpm-0	3-0	1.28-0	mariadb:11.8	4.2-0	valkey/valkey:9.1-alpine	2.9.8
-magento	2.4.8	8.4-fpm-2	3-0	1.28-0	mariadb:11.8	4.2-0	valkey/valkey:8.1-alpine	2.9.8
-magento	2.4.7	8.3-fpm-7	3-0	1.28-0	mariadb:11.8	4.2-0	valkey/valkey:8.1-alpine	2.9.8
+magento	2.4.8	8.4-fpm-2	3-0	1.28-0	mariadb:11.4	4.2-0	valkey/valkey:8.1-alpine	2.9.8
+magento	2.4.7	8.3-fpm-7	3-0	1.28-0	mariadb:10.6	4.2-0	valkey/valkey:8.1-alpine	2.9.8
 magento	2.4.6	8.2-fpm-9	2.12-0	1.28-0	mariadb:10.6	4.2-0	redis:7.2-alpine	2.2.28
 magento	2.4.5	8.1-fpm-9	1.2-0	1.22-0	mariadb:10.4	3.11-1	redis:6.2-alpine	2.2.28
 magento	2.4.4	8.1-fpm-9	1.2-0	1.26-0	mariadb:10.4	3.9-0	redis:7.2-alpine	2.2.28


### PR DESCRIPTION
## What

Corrects two DB image pins in the version auto-detect matrix (`compose/lib/versions.tsv`, added in #1434) that made a clean install of Magento 2.4.7/2.4.8 boot an unsupported MariaDB and fail at `setup:install`.

Closes #1404.

## Why

The matrix matches by Magento **minor** line (`2.4.7`, `2.4.8`, `2.4.9`) via a boundary-aware prefix, so a single pin has to be valid for the whole line — **including the GA release**, since `bin/download community 2.4.8` resolves `composer ...=2.4.8` to GA (not the latest patch).

Two rows pinned `mariadb:11.8`, which GA/early-patch installs reject:

| Line | Pinned | GA actually supports (MariaDB) | Result |
|---|---|---|---|
| 2.4.8 | `11.8` | ≤ **11.4** (11.8 added in 2.4.8-p5) | ❌ install fails |
| 2.4.7 | `11.8` | ≤ **10.6** (10.11 in p9, 11.8 only in p10) | ❌ install fails |
| 2.4.9 | `11.8` | 11.8 ✓ | ✅ ok |

This is the exact failure reported in #1404 — the follow-up reporter was on 2.4.8-p3 and got:

```
Current version of RDBMS is not supported. Used Version: 11.8.8-MariaDB-...
Supported versions: ... MariaDB-(10.2-10.6), MariaDB-11.4
```

## Fix

Pin each line to the version its **GA** supports (forward-safe for every patch in the line):

- `2.4.8` → `mariadb:11.4`
- `2.4.7` → `mariadb:10.6`
- `2.4.9` unchanged (`mariadb:11.8`, correct)

## Verification

- Cross-checked Magento's `supportedVersionPatterns` in `app/etc/di.xml` across tags `2.4.7`, `2.4.7-p9`, `2.4.7-p10`, `2.4.8`, `2.4.8-p3`, `2.4.8-p5`, `2.4.9`.
- Ran `versions_lookup` against the patched TSV:

```
magento 2.4.9     -> mariadb:11.8
magento 2.4.8     -> mariadb:11.4
magento 2.4.8-p3  -> mariadb:11.4
magento 2.4.7     -> mariadb:10.6
magento 2.4.7-p10 -> mariadb:10.6
magento 2.4.6     -> mariadb:10.6
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
