### PR TITLE
feat: add /release skill to automate cutting releases

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: release
+description: Cut a new docker-magento release end to end — analyze merged PRs since the last release, decide the next version, auto-generate CHANGELOG entries in the project's format, bump the compose.yaml version, land on master, tag, and publish the GitHub Release. Use when the user types /release or asks to cut/ship/publish a release.
+---
+
+# Release docker-magento
+
+Automates the full release. You (Claude) do the judgment — pick the version and
+write the changelog — then hand the mechanical git/gh work to
+`.claude/skills/release/release.sh`, which stamps, commits, lands on `master`,
+tags, and publishes.
+
+There is exactly **one approval gate**: after you present the proposed version +
+generated changelog + planned actions, wait for the user's go-ahead before
+running the script (the irreversible push/tag/publish happens there). If the
+user said something like "just do it" / "/release --yes", skip the pause.
+
+## Preconditions (verify first; abort with a clear message if any fail)
+
+- Current branch is `release/next`, clean working tree, in sync with `origin/release/next`.
+- `release/next` is ahead of `master` (there is something to release).
+- `gh` is authenticated, and the user is a repo admin (master is protected;
+  only admins can fast-forward it directly).
+
+Don't hand-fix these silently — tell the user what's wrong.
+
+## Step 1 — Gather what's shipping
+
+```bash
+git fetch --quiet origin release/next master --tags
+git log --no-merges --pretty='%s' origin/master..origin/release/next
+```
+
+Collect the PR numbers from the commit subjects (`(#1444)` etc.). For each,
+read title, body, and labels to understand the change — do not rely on the
+commit subject alone:
+
+```bash
+gh pr view <N> --json number,title,body,labels,url
+```
+
+Ignore pure-infra noise only if it truly doesn't affect users (but dependency
+bumps like `actions/checkout` usually still warrant a one-line entry).
+
+## Step 2 — Decide the version
+
+Versioning is SemVer with a single-incrementing scheme (history: 53.0.0,
+52.1.0, 52.0.2, …). From the change set:
+
+- **Major** (`NN.0.0`) — any breaking or behavior-changing default: new default
+  install target, removed/renamed scripts, changed socket paths, image
+  defaults users must react to. docker-magento bumps major readily.
+- **Minor** (`N.M.0`) — additive features, new images/scripts, no breaking change.
+- **Patch** (`N.M.P`) — bug fixes, dependency bumps, docs/CI only.
+
+Compute the next number from the **latest git tag**. State your reasoning in one
+line. The user can override in the approval step.
+
+## Step 3 — Generate the CHANGELOG entries (this is the automatic part)
+
+Write entries **into the existing `## [Unreleased]` section** of `CHANGELOG.md`,
+matching the project's established format exactly:
+
+- Group under `### Added`, `### Changed`, `### Fixed`, `### Removed` (only the
+  groups that apply, in that order).
+- One bullet per change, written as editorial prose — say *what* changed and,
+  where it matters, *why* / the user impact. Look at the `[53.0.0]` and
+  `[52.x]` entries already in the file and match their voice and depth.
+- End each bullet with inline links to the PR and any closed issue, e.g.
+  `[PR #1444](https://github.com/markshust/docker-magento/pull/1444)`,
+  `[#1404](https://github.com/markshust/docker-magento/issues/1404)`.
+- Bug-fix PRs → `### Fixed`; `feat:` → `### Added`/`### Changed`; breaking →
+  call it out explicitly (bold lead-in like the existing entries do).
+
+Use the Edit tool to insert these bullets under `## [Unreleased]`. Do **not**
+change the version heading or add a date — the script does that in Step 5.
+
+## Step 4 — Present for approval
+
+Show the user, concisely:
+1. Proposed version + one-line rationale.
+2. The changelog section you just wrote (rendered).
+3. What will happen: commit to `release/next`, fast-forward `master`, tag
+   `NN.N.N`, publish GitHub Release.
+
+Then stop and wait for approval (unless the user pre-authorized).
+
+## Step 5 — Execute
+
+```bash
+.claude/skills/release/release.sh <version> --yes
+```
+
+The script re-validates preconditions, stamps `## [Unreleased]` →
+`## [<version>] - <date>` (leaving a fresh empty `## [Unreleased]`), bumps the
+`## Version` line in `compose/compose.yaml`, commits as
+`chore: prep <version> release`, pushes `release/next`, fast-forwards and pushes
+`master`, tags, and creates the GitHub Release from the stamped changelog
+section. It prints the release URL.
+
+To preview without publishing, run with `--dry-run` instead of `--yes` — it
+stamps, shows the diff and the exact release notes, then reverts.
+
+## Step 6 — Report
+
+Give the user the published release URL and the version shipped. If the script
+aborted, relay its error verbatim and stop — don't try to force past a failed
+precondition.
+
+## Guardrails
+
+- Never invent a changelog entry for a change you didn't find in a merged PR.
+- Never bump the version past what the changes justify to "round up."
+- If `[Unreleased]` would be empty (nothing user-facing merged), say so and
+  ask whether to proceed — the script refuses an empty release anyway.
+- The script pushes directly to `master`; that's intentional and admin-gated.
+  Don't route it through a PR — the fast-forward is the release.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -15,6 +15,29 @@ generated changelog + planned actions, wait for the user's go-ahead before
 running the script (the irreversible push/tag/publish happens there). If the
 user said something like "just do it" / "/release --yes", skip the pause.
 
+## Arguments
+
+Anything the user types after `/release` is free-form context and **takes
+precedence over this skill's defaults** — treat it as an authoritative override.
+Read it first and let it steer the run. Common forms:
+
+- **Pin the version** — e.g. `/release use tag 53.0.1`, `/release 54.0.0`,
+  `/release this is just a patch`: skip the Step 2 computation and use what they
+  said. Still sanity-check it's a clean bump above the latest tag; if it looks
+  wrong (duplicate, lower than the last tag, skips several majors) flag it once,
+  but defer to the user if they confirm.
+- **Skip the approval gate** — `just do it`, `--yes`, `no confirm`: go straight
+  through Step 4 without pausing.
+- **Preview only** — `dry run`, `--dry-run`: run the script with `--dry-run`
+  instead of `--yes` and stop after showing the diff + notes.
+- **Steer the changelog** — `group the redis changes`, `don't mention the
+  checkout bump`, `call out the breaking default change`: fold into Step 3.
+- **Anything else** — honor any legitimate release instruction. If it collides
+  with a hard guardrail (empty `[Unreleased]`, a version at/below the latest
+  tag), explain the conflict and ask rather than silently overriding it.
+
+With no arguments, run the full flow using your own judgment.
+
 ## Preconditions (verify first; abort with a clear message if any fail)
 
 - Current branch is `release/next`, clean working tree, in sync with `origin/release/next`.
@@ -54,7 +77,9 @@ Versioning is SemVer with a single-incrementing scheme (history: 53.0.0,
 - **Patch** (`N.M.P`) — bug fixes, dependency bumps, docs/CI only.
 
 Compute the next number from the **latest git tag**. State your reasoning in one
-line. The user can override in the approval step.
+line. The user can override in the approval step — and if they pinned a version
+in the `/release` arguments (see **Arguments**), use that instead of computing
+one, after the sanity-check noted there.
 
 ## Step 3 — Generate the CHANGELOG entries (this is the automatic part)
 
@@ -99,7 +124,8 @@ The script re-validates preconditions, stamps `## [Unreleased]` →
 section. It prints the release URL.
 
 To preview without publishing, run with `--dry-run` instead of `--yes` — it
-stamps, shows the diff and the exact release notes, then reverts.
+stamps, shows the diff and the exact release notes, then reverts. Use
+`--dry-run` whenever the user asked for a preview in the arguments.
 
 ## Step 6 — Report
 

--- a/.claude/skills/release/release.sh
+++ b/.claude/skills/release/release.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# .claude/skills/release/release.sh <version> [--dry-run] [--yes]
+#
+# Mechanical half of the `/release` skill. Deterministic, no judgment: the
+# skill (Claude) decides the version number and writes the changelog entries
+# under `## [Unreleased]` FIRST, then hands off to this script to stamp,
+# commit, land on master, tag, and publish the GitHub Release.
+#
+# What it does, in order:
+#   1. Validate: semver arg, clean tree, on release/next & up to date with
+#      origin, gh authenticated, tag not already used, [Unreleased] non-empty.
+#   2. Stamp CHANGELOG.md: rename `## [Unreleased]` to `## [<version>] - <date>`
+#      and insert a fresh empty `## [Unreleased]` above it.
+#   3. Bump the `## Version <x>` comment at the top of compose/compose.yaml.
+#   4. Commit the two files to release/next as "chore: prep <version> release".
+#   5. Push release/next, fast-forward master to it, push master.
+#   6. Create + push tag <version>, then `gh release create` using the newly
+#      stamped changelog section as the release notes.
+#
+# Flags:
+#   --dry-run   Stamp the files, show the diff, then revert and exit. No commit,
+#               no push, no tag, no release.
+#   --yes       Skip the interactive "proceed to push/tag/publish?" prompt.
+#               The skill passes this after you approve in chat.
+#
+# Notes:
+#   - Must be run by a repo admin: master is protected (PRs required for
+#     non-admins) but enforce_admins is off, so an admin can fast-forward
+#     master directly. A non-admin push will be rejected.
+#   - Tags are bare semver (e.g. 54.0.0), no `v` prefix, matching history.
+#   - Bash 3.2 compatible (default macOS bash).
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+VERSION=""
+DRY_RUN=0
+ASSUME_YES=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --yes|-y)  ASSUME_YES=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    -*)        echo "Unknown flag: $1" >&2; exit 2 ;;
+    *)
+      if [ -z "$VERSION" ]; then VERSION="$1"; else
+        echo "Unexpected argument: $1" >&2; exit 2
+      fi
+      shift ;;
+  esac
+done
+
+RED='\033[0;31m'; YELLOW='\033[0;33m'; GREEN='\033[0;32m'; NC='\033[0m'
+die()  { printf "${RED}release: %s${NC}\n" "$1" >&2; exit 1; }
+note() { printf "${GREEN}release: %s${NC}\n" "$1"; }
+warn() { printf "${YELLOW}release: %s${NC}\n" "$1" >&2; }
+
+# --- Locate repo root (skill lives at .claude/skills/release/) -------------
+REPO_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$REPO_ROOT"
+
+CHANGELOG="CHANGELOG.md"
+COMPOSE="compose/compose.yaml"
+RELEASE_BRANCH="release/next"
+MAIN_BRANCH="master"
+
+# --- Validate input ---------------------------------------------------------
+[ -n "$VERSION" ] || { usage; exit 2; }
+case "$VERSION" in
+  v*) die "version must be bare semver without a 'v' prefix (got '$VERSION')." ;;
+esac
+printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' \
+  || die "invalid version '$VERSION'. Expected X.Y.Z (e.g. 54.0.0)."
+
+[ -f "$CHANGELOG" ] || die "$CHANGELOG not found — run from repo root."
+[ -f "$COMPOSE" ]   || die "$COMPOSE not found."
+
+# --- Preconditions ----------------------------------------------------------
+command -v gh >/dev/null 2>&1 || die "gh CLI is required (brew install gh)."
+gh auth status >/dev/null 2>&1 || die "gh is not authenticated (gh auth login)."
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+[ "$CURRENT_BRANCH" = "$RELEASE_BRANCH" ] \
+  || die "must be on '$RELEASE_BRANCH' (currently on '$CURRENT_BRANCH')."
+
+[ -z "$(git status --porcelain)" ] \
+  || die "working tree is not clean. Commit or stash first."
+
+git fetch --quiet origin "$RELEASE_BRANCH" "$MAIN_BRANCH" --tags
+[ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$RELEASE_BRANCH")" ] \
+  || die "local $RELEASE_BRANCH is not in sync with origin/$RELEASE_BRANCH."
+
+if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null \
+   || git ls-remote --exit-code --tags origin "$VERSION" >/dev/null 2>&1; then
+  die "tag '$VERSION' already exists."
+fi
+
+# master must be a strict ancestor of release/next so a fast-forward is valid.
+git merge-base --is-ancestor "origin/$MAIN_BRANCH" HEAD \
+  || die "origin/$MAIN_BRANCH is not an ancestor of $RELEASE_BRANCH — cannot fast-forward. Reconcile manually."
+
+if [ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$MAIN_BRANCH")" ]; then
+  die "nothing to release — $RELEASE_BRANCH has no commits beyond $MAIN_BRANCH."
+fi
+
+# --- Guard: [Unreleased] must contain at least one bullet -------------------
+UNRELEASED_BODY="$(awk '
+  /^## \[Unreleased\]$/ { cap=1; next }
+  cap && /^## \[/       { cap=0 }
+  cap                   { print }
+' "$CHANGELOG")"
+printf '%s\n' "$UNRELEASED_BODY" | grep -Eq '^- ' \
+  || die "the [Unreleased] section has no entries. The skill must write the changelog before calling this script."
+
+RELEASE_DATE="$(date +%F)"
+
+# --- Stamp CHANGELOG.md -----------------------------------------------------
+# Replace the first `## [Unreleased]` line with a fresh empty Unreleased
+# heading followed by the new version heading. Entries below stay put and
+# end up under the new version.
+awk -v ver="$VERSION" -v d="$RELEASE_DATE" '
+  !done && /^## \[Unreleased\]$/ {
+    print "## [Unreleased]"
+    print ""
+    print "## [" ver "] - " d
+    done=1
+    next
+  }
+  { print }
+' "$CHANGELOG" > "$CHANGELOG.tmp" && mv "$CHANGELOG.tmp" "$CHANGELOG"
+
+# --- Bump compose.yaml version comment --------------------------------------
+sed -i.bak -E "s/^(## Version ).*/\1${VERSION}/" "$COMPOSE" && rm -f "$COMPOSE.bak"
+grep -q "^## Version ${VERSION}$" "$COMPOSE" \
+  || die "failed to bump '## Version' line in $COMPOSE — is the comment present?"
+
+# --- Extract the just-stamped section for release notes ---------------------
+NOTES_FILE="$(mktemp)"
+trap 'rm -f "$NOTES_FILE"' EXIT
+awk -v ver="$VERSION" '
+  $0 ~ "^## \\[" ver "\\] - " { cap=1; next }
+  cap && /^## \[/             { cap=0 }
+  cap                         { print }
+' "$CHANGELOG" | sed -e '/./,$!d' | awk 'NF{blank=0} !NF{blank++} blank<2 || NF' > "$NOTES_FILE"
+
+echo
+note "Prepared release $VERSION (dated $RELEASE_DATE). File changes:"
+git --no-pager diff -- "$CHANGELOG" "$COMPOSE"
+echo
+note "Release notes that will be posted to GitHub:"
+echo "----------------------------------------------------------------------"
+cat "$NOTES_FILE"
+echo "----------------------------------------------------------------------"
+
+# --- Dry run stops here -----------------------------------------------------
+if [ "$DRY_RUN" -eq 1 ]; then
+  git checkout -- "$CHANGELOG" "$COMPOSE"
+  warn "--dry-run: reverted file changes, nothing committed or pushed."
+  exit 0
+fi
+
+# --- Confirm before anything irreversible -----------------------------------
+if [ "$ASSUME_YES" -ne 1 ]; then
+  printf "Proceed to commit, push %s + %s, tag %s, and publish the GitHub Release? [y/N] " \
+    "$RELEASE_BRANCH" "$MAIN_BRANCH" "$VERSION"
+  read -r reply
+  case "$reply" in
+    y|Y|yes|YES) : ;;
+    *) git checkout -- "$CHANGELOG" "$COMPOSE"; die "aborted by user; file changes reverted." ;;
+  esac
+fi
+
+# --- Commit, land on master, tag, publish -----------------------------------
+git add "$CHANGELOG" "$COMPOSE"
+git commit -q -m "chore: prep ${VERSION} release" -m "" \
+  -m "Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+git push --quiet origin "$RELEASE_BRANCH"
+note "Committed and pushed prep to $RELEASE_BRANCH."
+
+git checkout --quiet "$MAIN_BRANCH"
+git merge --quiet --ff-only "$RELEASE_BRANCH"
+git push --quiet origin "$MAIN_BRANCH"
+note "Fast-forwarded $MAIN_BRANCH to $RELEASE_BRANCH and pushed."
+
+git tag "$VERSION"
+git push --quiet origin "$VERSION"
+note "Tagged $VERSION."
+
+gh release create "$VERSION" --title "$VERSION" --target "$MAIN_BRANCH" --notes-file "$NOTES_FILE"
+
+git checkout --quiet "$RELEASE_BRANCH"
+note "Done. Back on $RELEASE_BRANCH."
+gh release view "$VERSION" --json url -q .url


### PR DESCRIPTION
## What

Adds a maintainer-only `/release` skill that cuts a full docker-magento release from a single invocation.

`.claude/skills/release/`
- **`SKILL.md`** — orchestration + judgment: analyze merged PRs since the last release, pick the next SemVer version, and auto-generate `CHANGELOG.md` entries in the project's existing editorial format (grouped Added/Changed/Fixed, inline PR/issue links). One approval gate before anything irreversible.
- **`release.sh`** — deterministic git/gh mechanics: precondition checks → stamp `[Unreleased]` → `[version] - date` + bump the `## Version` line in `compose/compose.yaml` → commit `chore: prep <version> release` → fast-forward `master` → tag → `gh release create` from the stamped changelog section. Bash 3.2 compatible; supports `--dry-run`.

## Why this targets `release/next` (not `master` directly)

`release.sh` fast-forwards `master` to `release/next` as the actual release step, so it requires `master` to remain a strict **ancestor** of `release/next`. Landing this skill on `master` alone would break that invariant and the script's own precondition check. Merging into `release/next` keeps the release mechanism valid, gets the tooling reviewed/committed before any real release, and the **first `/release` run carries `.claude/` onto `master`** as part of the fast-forward.

## Not shipped to Magento installs

The skill lives at repo-root `.claude/` — **not** under `compose/`. The installer (`lib/template`, used by the one-line script and `bin/update`) sparse-checks out only the `compose/` subtree (`git checkout origin/master -- compose`), so `.claude/` is excluded automatically, exactly like `.github/`, `docs/`, `images/`, and `lib/`. Verified.

## Verification

- `bash -n release.sh` — syntax OK.
- Reviewed the CHANGELOG structure (no compare-link refs; inline PR links) and the shellcheck path-gating (`compose/bin/**`, so a prep commit needs no CI wait) that shaped the script.
- `--dry-run` path stamps, prints the diff + exact release notes, then reverts — run it once before the first real release to sanity-check output.

## First use

After merge, from `release/next`: `/release` (or `.claude/skills/release/release.sh <version> --dry-run` to preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
