### PR TITLE
fix: make /release a single-commit flow, tolerate the skill's CHANGELOG edit

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -99,6 +99,10 @@ matching the project's established format exactly:
 
 Use the Edit tool to insert these bullets under `## [Unreleased]`. Do **not**
 change the version heading or add a date — the script does that in Step 5.
+**Leave this edit uncommitted** — the Step 5 script stamps on top of it and
+folds it into the single `chore: prep <version> release` commit. Do not commit
+`CHANGELOG.md` yourself; a stray manual commit produces a redundant second
+commit on the release.
 
 ## Step 4 — Present for approval
 
@@ -116,12 +120,14 @@ Then stop and wait for approval (unless the user pre-authorized).
 .claude/skills/release/release.sh <version> --yes
 ```
 
-The script re-validates preconditions, stamps `## [Unreleased]` →
-`## [<version>] - <date>` (leaving a fresh empty `## [Unreleased]`), bumps the
-`## Version` line in `compose/compose.yaml`, commits as
-`chore: prep <version> release`, pushes `release/next`, fast-forwards and pushes
-`master`, tags, and creates the GitHub Release from the stamped changelog
-section. It prints the release URL.
+The script re-validates preconditions (it tolerates the uncommitted
+`CHANGELOG.md` from Step 3 but aborts on any other dirty path), stamps
+`## [Unreleased]` → `## [<version>] - <date>` (leaving a fresh empty
+`## [Unreleased]`), bumps the `## Version` line in `compose/compose.yaml`, then
+`git add`s both files and makes a single commit `chore: prep <version> release`
+— so your Step 3 changelog prose and the version stamp land together. It pushes
+`release/next`, fast-forwards and pushes `master`, tags, and creates the GitHub
+Release from the stamped changelog section. It prints the release URL.
 
 To preview without publishing, run with `--dry-run` instead of `--yes` — it
 stamps, shows the diff and the exact release notes, then reverts. Use

--- a/.claude/skills/release/release.sh
+++ b/.claude/skills/release/release.sh
@@ -8,8 +8,9 @@
 # commit, land on master, tag, and publish the GitHub Release.
 #
 # What it does, in order:
-#   1. Validate: semver arg, clean tree, on release/next & up to date with
-#      origin, gh authenticated, tag not already used, [Unreleased] non-empty.
+#   1. Validate: semver arg, clean tree (apart from the skill's CHANGELOG.md
+#      edit), on release/next & up to date with origin, gh authenticated, tag
+#      not already used, [Unreleased] non-empty.
 #   2. Stamp CHANGELOG.md: rename `## [Unreleased]` to `## [<version>] - <date>`
 #      and insert a fresh empty `## [Unreleased]` above it.
 #   3. Bump the `## Version <x>` comment at the top of compose/compose.yaml.
@@ -88,8 +89,13 @@ CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 [ "$CURRENT_BRANCH" = "$RELEASE_BRANCH" ] \
   || die "must be on '$RELEASE_BRANCH' (currently on '$CURRENT_BRANCH')."
 
-[ -z "$(git status --porcelain)" ] \
-  || die "working tree is not clean. Commit or stash first."
+# The skill (Step 3) writes the [Unreleased] entries into CHANGELOG.md before
+# calling this script, so an uncommitted CHANGELOG.md is the expected state — it
+# gets stamped below and folded into the single "chore: prep" commit. Any OTHER
+# dirty path is a real problem and aborts.
+DIRTY="$(git status --porcelain | awk '$0 !~ /[ \/]CHANGELOG\.md$/')"
+[ -z "$DIRTY" ] \
+  || die "working tree has uncommitted changes other than CHANGELOG.md. Commit or stash first."
 
 git fetch --quiet origin "$RELEASE_BRANCH" "$MAIN_BRANCH" --tags
 [ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/$RELEASE_BRANCH")" ] \


### PR DESCRIPTION
## What

Fixes a self-inflicted precondition failure in the `/release` skill surfaced on its first real use (cutting 53.0.1).

`release.sh`'s clean-tree check rejected the uncommitted `CHANGELOG.md` that the skill's **Step 3 is required to write**, so the script couldn't run until the changelog prose was committed manually first — producing a redundant second commit (`docs: ...` + `chore: prep ...`) on the release.

## Fix

- **`release.sh`** — relax the clean-tree precondition to tolerate an uncommitted `CHANGELOG.md` (and *only* that; any other dirty path still aborts). The script already `git add`s `CHANGELOG.md` + `compose.yaml` and makes one commit, so the changelog prose now folds into the single `chore: prep <version> release` commit.
- **`SKILL.md`** — Step 3 now says to leave the changelog edit uncommitted; Step 5 documents that the script tolerates it and lands everything in one commit.

## Result

The `/release` flow is single-commit again and no longer trips on its own precondition.

## Verification

- `bash -n release.sh` — syntax OK.
- Tested the dirty-path awk filter: ` M CHANGELOG.md` → tolerated; ` M compose/compose.yaml` → still flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)